### PR TITLE
Make some tweaks to the animations

### DIFF
--- a/ooniprobe/View/TestResults/Rows/DashboardTableViewCell.m
+++ b/ooniprobe/View/TestResults/Rows/DashboardTableViewCell.m
@@ -15,13 +15,25 @@
 - (void)setHighlighted:(BOOL)highlighted animated:(BOOL)animated{
     [super setHighlighted:highlighted animated:animated];
     if (highlighted) {
-        [UIView animateWithDuration:0.15f animations:^{
-            self.contentView.alpha = 0.5f;
-        }];
+        [UIView
+            animateWithDuration:0.3f
+            delay:0
+            options:UIViewAnimationOptionCurveEaseOut
+            animations:^{
+                self.contentView.alpha = 0.7f;
+            }
+            completion: NULL
+         ];
     } else {
-        [UIView animateWithDuration:0.35f animations:^{
-            self.contentView.alpha = 1.f;
-        }];
+        [UIView
+         animateWithDuration:0.8f
+         delay:0.5f
+         options:UIViewAnimationOptionCurveEaseInOut
+         animations:^{
+             self.contentView.alpha = 1.f;
+         }
+         completion: NULL
+        ];
     }
 }
 


### PR DESCRIPTION
I made some changes to the animations for the card highlight.

Namely:

1. Adjust the opacity to 0.7
2. Change the curve for the enter animation to be easeout (we want it to be highlighted quickly when you tap it and then slow down towards the end as you hold it)
3. Add a subtle delay to the exit animation