### PR TITLE
Update to mkall-ios v0.3.10

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Fabric (1.9.0)
   - lottie-ios (2.5.2)
   - MBProgressHUD (1.1.0)
-  - mkall (0.3.9)
+  - mkall (0.3.10)
   - MKDropdownMenu (1.4)
   - OCMapper (2.0)
   - RHMarkdownLabel (0.0.1):
@@ -53,7 +53,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   mkall:
-    :commit: 051006b36ebf4eee3cb0e6399a7247939c4e4dd6
+    :commit: adc25f544505da545f12672957b35eba01b83d21
     :git: https://github.com/measurement-kit/mkall-ios.git
 
 SPEC CHECKSUMS:
@@ -63,7 +63,7 @@ SPEC CHECKSUMS:
   Fabric: f988e33c97f08930a413e08123064d2e5f68d655
   lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
-  mkall: 70af913981864b5e4ec0a5972b19c5b2063e2a34
+  mkall: b20629ad11e58e8b14a01e03d35df896234a89af
   MKDropdownMenu: 269df4a41d21a1db684ce8bc709befe419fc5bae
   OCMapper: 9b4d542543794c42adc01f1493d894f53e193cb0
   RHMarkdownLabel: 81d6772768e621be57302b7fd5212ad4f78fb0bd


### PR DESCRIPTION
This PR changes the build to use mkall-ios v0.3.10 (i.e. MK v0.9.3).