### PR TITLE
Fix/database managment

### DIFF
--- a/ooniprobe/Info.plist
+++ b/ooniprobe/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.3</string>
+	<string>2.0.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -30,7 +30,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>61</string>
+	<string>62</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>

--- a/ooniprobe/Test/Suite/AbstractSuite.mm
+++ b/ooniprobe/Test/Suite/AbstractSuite.mm
@@ -43,6 +43,8 @@
     //if last test
     if ([self.testList count] == 0){
         [self.result setIs_done:YES];
+        [self.result save];
+        //Resetting class values
         self.result = nil;
         self.measurementIdx = 0;
         UIApplicationState state = [[UIApplication sharedApplication] applicationState];

--- a/ooniprobe/Test/Suite/AbstractSuite.mm
+++ b/ooniprobe/Test/Suite/AbstractSuite.mm
@@ -24,7 +24,6 @@
 }
 
 -(void)runTestSuite {
-    self.measurementIdx = 0;
     [self newResult];
     self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
@@ -45,6 +44,7 @@
     if ([self.testList count] == 0){
         [self.result setIs_done:YES];
         self.result = nil;
+        self.measurementIdx = 0;
         UIApplicationState state = [[UIApplication sharedApplication] applicationState];
         if (state == UIApplicationStateBackground || state == UIApplicationStateInactive){
             if ([SettingsUtility getSettingWithName:@"notifications_enabled"] && [SettingsUtility getSettingWithName:@"notifications_completion"])

--- a/ooniprobe/Test/Suite/AbstractSuite.mm
+++ b/ooniprobe/Test/Suite/AbstractSuite.mm
@@ -44,6 +44,7 @@
     //if last test
     if ([self.testList count] == 0){
         [self.result setIs_done:YES];
+        self.result = nil;
         UIApplicationState state = [[UIApplication sharedApplication] applicationState];
         if (state == UIApplicationStateBackground || state == UIApplicationStateInactive){
             if ([SettingsUtility getSettingWithName:@"notifications_enabled"] && [SettingsUtility getSettingWithName:@"notifications_completion"])
@@ -69,10 +70,13 @@
 }
 
 -(void)newResult {
-    self.result = [Result new];
-    [self.result setTest_group_name:self.name];
-    //The Result object needs to be saved to have an Id, needed for log
-    [self.result save];
+    //For rerun measurement result is set by the view controller
+    if (self.result == nil){
+        self.result = [Result new];
+        [self.result setTest_group_name:self.name];
+        //The Result object needs to be saved to have an Id, needed for log
+        [self.result save];
+    }
 }
 
 -(int)getRuntime{

--- a/ooniprobe/View/Settings/SettingsTableViewController.m
+++ b/ooniprobe/View/Settings/SettingsTableViewController.m
@@ -46,7 +46,7 @@
 -(void)viewWillDisappear:(BOOL)animated{
     [super viewWillDisappear:animated];
     if (testSuite != nil){
-        testSuite.testList = nil;
+        [testSuite.testList removeAllObjects];
         [testSuite getTestList];
         [[NSNotificationCenter defaultCenter] postNotificationName:@"settingsChanged" object:nil];
     }

--- a/ooniprobe/it.lproj/Localizable.strings
+++ b/ooniprobe/it.lproj/Localizable.strings
@@ -116,7 +116,7 @@
 "TestResults.Details.RawData" = "Dati";
 "TestResults.Details.CopyToClipboard" = "Copia sugli Appunti";
 "TestResults.Details.Websites.Reachable.Hero.Title" = "Accessibile";
-"TestResults.Details.Websites.Reachable.Content.Paragraph" = "%@ non è accessibile";
+"TestResults.Details.Websites.Reachable.Content.Paragraph" = "%@ è accessibile";
 "TestResults.Details.Websites.LikelyBlocked.Hero.Title" = "Probabilmente bloccato";
 "TestResults.Details.Websites.LikelyBlocked.Content.Paragraph" = "%@ è probabilmente bloccato per mezzo di %@.\n\nNota bene: Possono esserci falsi positivi. [Per saperne di più](https://ooni.io/nettest/web-connectivity/).";
 "TestResults.Details.Websites.LikelyBlocked.Content.LearnToCircumvent" = "Aggirare la censura";


### PR DESCRIPTION
Fixes 
- "0 seconds" shown in the overview instead of the actual runtime when open and closing the settings
- Re-run test creates another entry
