### PR TITLE
init shared instance once #223 #222

### DIFF
--- a/ooniprobe/AppDelegate.mm
+++ b/ooniprobe/AppDelegate.mm
@@ -25,6 +25,10 @@
     [[UINavigationBar appearance] setBarTintColor:[UIColor colorWithRGBHexString:color_blue5 alpha:1.0f]];
     [[UINavigationBar appearance] setTranslucent:FALSE];
 
+    InCodeMappingProvider *inCodeMappingProvider = [InCodeMappingProvider new];
+    [inCodeMappingProvider mapFromPropertyKey:@"ca_bundle_path" toDictionaryKey:@"net/ca_bundle_path" forClass:[Options class]];
+    [[ObjectMapper sharedInstance] setMappingProvider:inCodeMappingProvider];
+
     #ifdef RELEASE
     CrashlyticsKit.delegate = self;
     [Fabric with:@[[Crashlytics class]]];

--- a/ooniprobe/AppDelegate.mm
+++ b/ooniprobe/AppDelegate.mm
@@ -25,10 +25,8 @@
     [[UINavigationBar appearance] setBarTintColor:[UIColor colorWithRGBHexString:color_blue5 alpha:1.0f]];
     [[UINavigationBar appearance] setTranslucent:FALSE];
 
-    InCodeMappingProvider *inCodeMappingProvider = [InCodeMappingProvider new];
-    [inCodeMappingProvider mapFromPropertyKey:@"ca_bundle_path" toDictionaryKey:@"net/ca_bundle_path" forClass:[Options class]];
-    [[ObjectMapper sharedInstance] setMappingProvider:inCodeMappingProvider];
-
+    [self setMappingProvider];
+    
     #ifdef RELEASE
     CrashlyticsKit.delegate = self;
     [Fabric with:@[[Crashlytics class]]];
@@ -75,6 +73,16 @@
     [SettingsUtility set_push_token:token];
     [NotificationService updateClient];
 #endif
+}
+
+-(void)setMappingProvider{
+    if ([ObjectMapper sharedInstance].mappingProvider == nil){
+        InCodeMappingProvider *inCodeMappingProvider = [InCodeMappingProvider new];
+        [inCodeMappingProvider mapFromPropertyKey:@"ca_bundle_path" toDictionaryKey:@"net/ca_bundle_path" forClass:[Options class]];
+        [[ObjectMapper sharedInstance] setMappingProvider:inCodeMappingProvider];
+        NSLog(@"mappingProvider setting %@", [ObjectMapper sharedInstance].mappingProvider);
+    }
+    NSLog(@"mappingProvider is set %@", [ObjectMapper sharedInstance].mappingProvider);
 }
 
 - (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
@@ -165,6 +173,7 @@
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
     // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    [self setMappingProvider];
     if (![[UIApplication sharedApplication] isRegisteredForRemoteNotifications])
         [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"notifications_enabled"];
 }

--- a/ooniprobe/Model/Settings/Settings.m
+++ b/ooniprobe/Model/Settings/Settings.m
@@ -17,9 +17,6 @@
 }
 
 -(NSDictionary*)getSettingsDictionary{
-    InCodeMappingProvider *inCodeMappingProvider = [InCodeMappingProvider new];
-    [inCodeMappingProvider mapFromPropertyKey:@"ca_bundle_path" toDictionaryKey:@"net/ca_bundle_path" forClass:[Options class]];
-    [[ObjectMapper sharedInstance] setMappingProvider:inCodeMappingProvider];
     return [self dictionary];
 }
 

--- a/ooniprobe/Test/Test/AbstractTest.mm
+++ b/ooniprobe/Test/Test/AbstractTest.mm
@@ -53,13 +53,14 @@
 }
 
 -(void)runTest{
+    NSDictionary *settings = [self.settings getSettingsDictionary];
     self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
         self.backgroundTask = UIBackgroundTaskInvalid;
     }];
     dispatch_async(
                    dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-                       MKTask *task = [MKTask startNettest:[self.settings getSettingsDictionary]];
+                       MKTask *task = [MKTask startNettest:settings];
                        while (![task isDone]){
                            // Extract an event from the task queue and unmarshal it.
                            NSDictionary *evinfo = [task waitForNextEvent];


### PR DESCRIPTION
Fixes #223 #222

## Proposed Changes

  - Setting InCodeMappingProvider only once.
It is needed we use the shared instance as the function `dictionary` uses that sharedInstance
https://github.com/aryaxt/OCMapper/blob/master/OCMapper/Source/Categories/NSObject+ObjectMapper.m#L39
