### PR TITLE
Fix thread managment

### DIFF
--- a/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
+++ b/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
@@ -82,6 +82,7 @@
         });
         if ([notUploaded count] == 0) return;
         float progress = 0.0f;
+        //TODO the progress should consider the startAt not all the count
         float measurementValue = 1.0/[notUploaded count];
         NSUInteger i = idx;
         while (i < [notUploaded count]){

--- a/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
+++ b/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
@@ -82,15 +82,15 @@
         });
         if ([notUploaded count] == 0) return;
         float progress = 0.0f;
-        //TODO the progress should consider the startAt not all the count
-        float measurementValue = 1.0/[notUploaded count];
+        //The progress should consider the array size - the idx of first element to actually be uploaded
+        float measurementValue = 1.0/([notUploaded count] - idx);
         NSUInteger i = idx;
         while (i < [notUploaded count]){
             Measurement *currentMeasurement = [notUploaded objectAtIndex:i];
             dispatch_async(dispatch_get_main_queue(), ^{
                 [MBProgressHUD HUDForView:self.navigationController.view].label.text =
                 NSLocalizedFormatString(@"Modal.ResultsNotUploaded.Uploading",
-                                        [NSString stringWithFormat:@"%ld/%ld", i+1, [notUploaded count]]);
+                                        [NSString stringWithFormat:@"%ld/%ld", i+1, ([notUploaded count] - idx)]);
             });
             if (![self uploadMeasurement:currentMeasurement]){
                 dispatch_async(dispatch_get_main_queue(), ^{

--- a/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
+++ b/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
@@ -127,9 +127,6 @@
         [measurement setReport_id:[results updatedReportID]];
         [measurement save];
     }
-    else
-        printf("%s", [[results logs] UTF8String]);
-        //NSLog(@"%@", [results logs]);
     return [results good];
 }
 

--- a/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
+++ b/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
@@ -81,16 +81,16 @@
             hud.mode = MBProgressHUDModeAnnularDeterminate;
         });
         if ([notUploaded count] == 0) return;
+        NSUInteger i = idx;
         float progress = 0.0f;
         //The progress should consider the array size - the idx of first element to actually be uploaded
-        float measurementValue = 1.0/([notUploaded count] - idx);
-        NSUInteger i = idx;
+        float measurementValue = 1.0/([notUploaded count] - i);
         while (i < [notUploaded count]){
             Measurement *currentMeasurement = [notUploaded objectAtIndex:i];
             dispatch_async(dispatch_get_main_queue(), ^{
                 [MBProgressHUD HUDForView:self.navigationController.view].label.text =
                 NSLocalizedFormatString(@"Modal.ResultsNotUploaded.Uploading",
-                                        [NSString stringWithFormat:@"%ld/%ld", i+1, ([notUploaded count] - idx)]);
+                                        [NSString stringWithFormat:@"%ld/%ld", i+1, ([notUploaded count] - i)]);
             });
             if (![self uploadMeasurement:currentMeasurement]){
                 dispatch_async(dispatch_get_main_queue(), ^{


### PR DESCRIPTION
We want to use threads only for the actual `uploadMeasurements` function, and interrupt it in case of an error