### PR TITLE
Closes #284

### DIFF
--- a/ooniprobe/Test/Suite/AbstractSuite.mm
+++ b/ooniprobe/Test/Suite/AbstractSuite.mm
@@ -44,14 +44,14 @@
     if ([self.testList count] == 0){
         [self.result setIs_done:YES];
         [self.result save];
-        //Resetting class values
-        self.result = nil;
-        self.measurementIdx = 0;
         UIApplicationState state = [[UIApplication sharedApplication] applicationState];
         if (state == UIApplicationStateBackground || state == UIApplicationStateInactive){
             if ([SettingsUtility getSettingWithName:@"notifications_enabled"] && [SettingsUtility getSettingWithName:@"notifications_completion"])
                 [self showNotification];
         }
+        //Resetting class values
+        self.result = nil;
+        self.measurementIdx = 0;
         [[NSNotificationCenter defaultCenter] postNotificationName:@"networkTestEnded" object:nil];
     }
     [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];


### PR DESCRIPTION
Fixes #284

## Proposed Changes

  - the `showNotification` method uses `self.result.test_group_name` I will null result after the notification is sent
