### PR TITLE
Add API to fetch measurement URL

### DIFF
--- a/OONIProbeUnitTests/APITest.m
+++ b/OONIProbeUnitTests/APITest.m
@@ -1,0 +1,40 @@
+#import <XCTest/XCTest.h>
+#import "Measurement.h"
+#define EXISTING_REPORT_ID @"20190113T202156Z_AS327931_CgoC3KbgM6zKajvIIt1AxxybJ1HbjwwWJjsJnlxy9rpcGY54VH"
+#define NONEXISTING_REPORT_ID @"EMPTY"
+
+@interface APITest : XCTestCase
+
+@end
+
+@implementation APITest
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExisting {
+    Measurement *measurement = [Measurement new];
+    measurement.report_id = EXISTING_REPORT_ID;
+    [measurement getExplorerUrl:^(NSString *measurement_url){
+        XCTAssert(true);
+    } onError:^(NSError *error){
+        XCTAssert(false);
+    }];
+}
+
+- (void)testNonExisting {
+    Measurement *measurement = [Measurement new];
+    measurement.report_id = NONEXISTING_REPORT_ID;
+    [measurement getExplorerUrl:^(NSString *measurement_url){
+        XCTAssert(false);
+    } onError:^(NSError *error){
+        XCTAssert(true);
+    }];
+}
+
+@end

--- a/OONIProbeUnitTests/APITest.m
+++ b/OONIProbeUnitTests/APITest.m
@@ -1,5 +1,6 @@
 #import <XCTest/XCTest.h>
 #import "Measurement.h"
+#import "TestUtility.h"
 #define EXISTING_REPORT_ID @"20190113T202156Z_AS327931_CgoC3KbgM6zKajvIIt1AxxybJ1HbjwwWJjsJnlxy9rpcGY54VH"
 #define NONEXISTING_REPORT_ID @"EMPTY"
 
@@ -34,6 +35,14 @@
         XCTAssert(false);
     } onError:^(NSError *error){
         XCTAssert(true);
+    }];
+}
+
+-(void)testDownloadUrls{
+    [TestUtility downloadUrls:^(NSArray *urls) {
+        XCTAssert(true);
+    } onError:^(NSError *error) {
+        XCTAssert(false);
     }];
 }
 

--- a/OONIProbeUnitTests/APITest.m
+++ b/OONIProbeUnitTests/APITest.m
@@ -19,6 +19,7 @@
 }
 
 - (void)testExisting {
+    //TODO test getExplorerUrlCallback with custom NSData
     Measurement *measurement = [Measurement new];
     measurement.report_id = EXISTING_REPORT_ID;
     [measurement getExplorerUrl:^(NSString *measurement_url){
@@ -39,6 +40,7 @@
 }
 
 -(void)testDownloadUrls{
+    //TODO test downloadUrlsCallback with custom NSData
     [TestUtility downloadUrls:^(NSArray *urls) {
         XCTAssert(true);
     } onError:^(NSError *error) {

--- a/ooniprobe.xcodeproj/project.pbxproj
+++ b/ooniprobe.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		EDF20735212173B9005B06D7 /* Simple.m in Sources */ = {isa = PBXBuildFile; fileRef = EDF20733212173B8005B06D7 /* Simple.m */; };
 		EDF20736212173B9005B06D7 /* Advanced.m in Sources */ = {isa = PBXBuildFile; fileRef = EDF20734212173B9005B06D7 /* Advanced.m */; };
 		EDF23EF92228CC6000B97520 /* NetworkTest.m in Sources */ = {isa = PBXBuildFile; fileRef = EDF23EF82228CC6000B97520 /* NetworkTest.m */; };
+		EDF8E51D22C40A8E00CF0FF6 /* APITest.m in Sources */ = {isa = PBXBuildFile; fileRef = EDF8E51C22C40A8E00CF0FF6 /* APITest.m */; };
 		EDFE073D1F375E3C00960AF2 /* DictionaryUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = EDFE073C1F375E3C00960AF2 /* DictionaryUtility.m */; };
 /* End PBXBuildFile section */
 
@@ -367,6 +368,7 @@
 		EDF23EEB2225258100B97520 /* OONIProbeUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OONIProbeUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EDF23EEF2225258100B97520 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EDF23EF82228CC6000B97520 /* NetworkTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NetworkTest.m; sourceTree = "<group>"; };
+		EDF8E51C22C40A8E00CF0FF6 /* APITest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = APITest.m; sourceTree = "<group>"; };
 		EDFE073B1F375E3C00960AF2 /* DictionaryUtility.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DictionaryUtility.h; path = Utility/DictionaryUtility.h; sourceTree = "<group>"; };
 		EDFE073C1F375E3C00960AF2 /* DictionaryUtility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = DictionaryUtility.m; path = Utility/DictionaryUtility.m; sourceTree = "<group>"; };
 		FBB68CFBE135C2F6BDF61340 /* Pods-ooniprobe.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ooniprobe.release.xcconfig"; path = "Pods/Target Support Files/Pods-ooniprobe/Pods-ooniprobe.release.xcconfig"; sourceTree = "<group>"; };
@@ -852,6 +854,7 @@
 				EDF23EF82228CC6000B97520 /* NetworkTest.m */,
 				ED3BF19D2260BF6B00F9A3B2 /* TestKeysTest.m */,
 				ED5BC3C6229568FB00E311D7 /* MakeTimeoutTest.m */,
+				EDF8E51C22C40A8E00CF0FF6 /* APITest.m */,
 			);
 			path = OONIProbeUnitTests;
 			sourceTree = "<group>";
@@ -1264,6 +1267,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EDF23EF92228CC6000B97520 /* NetworkTest.m in Sources */,
+				EDF8E51D22C40A8E00CF0FF6 /* APITest.m in Sources */,
 				ED5BC3C7229568FB00E311D7 /* MakeTimeoutTest.m in Sources */,
 				ED3BF19E2260BF6B00F9A3B2 /* TestKeysTest.m in Sources */,
 				EDAE20FB22677BE50080FBCD /* ResultTest.m in Sources */,

--- a/ooniprobe/Model/Database/Measurement.h
+++ b/ooniprobe/Model/Database/Measurement.h
@@ -38,5 +38,5 @@
 -(void)save;
 -(void)setReRun;
 -(void)deleteObject;
--(void)getExplorerUrl:(void (^)(NSString*))successcb error:(void (^)(NSError*))errorcb;
+-(void)getExplorerUrl:(void (^)(NSString*))successcb onError:(void (^)(NSError*))errorcb;
 @end

--- a/ooniprobe/Model/Database/Measurement.h
+++ b/ooniprobe/Model/Database/Measurement.h
@@ -38,5 +38,5 @@
 -(void)save;
 -(void)setReRun;
 -(void)deleteObject;
--(void)getExplorerUrl:(void (^)(NSString *))measurement_url;
+-(void)getExplorerUrlSuccessCallback:(void (^)(NSString*))success errorCallback:(void (^)(NSError*))error;
 @end

--- a/ooniprobe/Model/Database/Measurement.h
+++ b/ooniprobe/Model/Database/Measurement.h
@@ -36,5 +36,5 @@
 -(void)save;
 -(void)setReRun;
 -(void)deleteObject;
-
+-(void)getExplorerUrl:(void (^)(NSString *))measurement_url;
 @end

--- a/ooniprobe/Model/Database/Measurement.h
+++ b/ooniprobe/Model/Database/Measurement.h
@@ -38,5 +38,5 @@
 -(void)save;
 -(void)setReRun;
 -(void)deleteObject;
--(void)getExplorerUrlSuccessCallback:(void (^)(NSString*))success errorCallback:(void (^)(NSError*))error;
+-(void)getExplorerUrl:(void (^)(NSString*))successcb error:(void (^)(NSError*))errorcb;
 @end

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -117,8 +117,7 @@
              return;
          }
          NSArray *resultsArray = [dic objectForKey:@"results"];
-         //TODO symbolize somehow empty array
-         if ([resultsArray count] <= 0) {
+         if ([resultsArray count] <= 0 || ![[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]) {
              errorcb([NSError errorWithDomain:@"io.ooni.api"
                                          code:ERR_JSON_EMPTY
                                      userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -96,7 +96,7 @@
     [self remove];
 }
 
--(void)getExplorerUrl:(void (^)(NSString*))successcb error:(void (^)(NSError*))errorcb {
+-(void)getExplorerUrl:(void (^)(NSString*))successcb onError:(void (^)(NSError*))errorcb {
     NSLog(@"%@ getExplorerUrl",self.Id);
     NSMutableString *path = [NSMutableString stringWithFormat:@"https://api.ooni.io/api/v1/measurements?report_id=%@",
                       self.report_id];
@@ -120,7 +120,7 @@
          //TODO symbolize somehow empty array
          if ([resultsArray count] <= 0) {
              errorcb([NSError errorWithDomain:@"io.ooni.api"
-                                         code:100
+                                         code:JSON_EMPTY_CODE
                                      userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
                                                 }]);
              return;

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -97,13 +97,17 @@
 }
 
 -(void)getExplorerUrl:(void (^)(NSString*))successcb onError:(void (^)(NSError*))errorcb {
-    NSLog(@"%@ getExplorerUrl",self.Id);
-    NSMutableString *path = [NSMutableString stringWithFormat:@"https://api.ooni.io/api/v1/measurements?report_id=%@",
-                      self.report_id];
+    NSURLComponents *components = [[NSURLComponents alloc] init];
+    components.scheme = @"https";
+    components.host = @"api.ooni.io";
+    components.path = @"/api/v1/measurements";
     if ([self.test_name isEqualToString:@"web_connectivity"])
-        [path appendString:[NSString stringWithFormat:@"&input=%@",
-                            self.url_id.url]];
-    NSURL *url = [NSURL URLWithString:path];
+        components.query = [NSString stringWithFormat:@"report_id=%@&input=%@",
+                            self.report_id, self.url_id.url];
+    else
+        components.query = [NSString stringWithFormat:@"report_id=%@",
+                        self.report_id];
+    NSURL *url = components.URL;
     NSURLSessionDataTask *downloadTask = [[NSURLSession sharedSession]
      dataTaskWithURL:url
      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -104,7 +104,7 @@
     NSURLQueryItem *reportIdItem = [NSURLQueryItem
                                     queryItemWithName:@"report_id"
                                     value:self.report_id];
-
+    //web_connectivity is the only test using input for now
     if ([self.test_name isEqualToString:@"web_connectivity"]){
         NSURLQueryItem *urlItem = [NSURLQueryItem
                                    queryItemWithName:@"input"

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -96,7 +96,7 @@
     [self remove];
 }
 
--(void)getExplorerUrlSuccessCallback:(void (^)(NSString*))success errorCallback:(void (^)(NSError*))error {
+-(void)getExplorerUrl:(void (^)(NSString*))successcb error:(void (^)(NSError*))errorcb {
     NSLog(@"%@ getExplorerUrl",self.Id);
     NSMutableString *path = [NSMutableString stringWithFormat:@"https://api.ooni.io/api/v1/measurements?report_id=%@",
                       self.report_id];
@@ -107,21 +107,21 @@
     NSURLSessionDataTask *downloadTask =
     [[NSURLSession sharedSession]
      dataTaskWithURL:url
-     completionHandler:^(NSData *data, NSURLResponse *response, NSError *nserror) {
+     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
          if (nserror != nil)
-             error(nserror);
+             errorcb(error);
          else {
-             NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&nserror];
-             if (nserror != nil)
-                 error(nserror);
+             NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+             if (error != nil)
+                 errorcb(error);
              NSArray *resultsArray = [dic objectForKey:@"results"];
              //TODO symbolize somehow empty array
              if ([resultsArray count] == 0)
-                 error([NSError errorWithDomain:@"io.ooni.api"
+                 errorcb([NSError errorWithDomain:@"io.ooni.api"
                                            code:100
                                        userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
                                                   }];);
-             success([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
+             successcb([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
          }
     }];
     [downloadTask resume];

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -108,19 +108,25 @@
     [[NSURLSession sharedSession]
      dataTaskWithURL:url
      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-         if (error != nil)
+         if (error != nil){
              errorcb(error);
+             return;
+         }
          else {
              NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
-             if (error != nil)
+             if (error != nil){
                  errorcb(error);
+                 return;
+             }
              NSArray *resultsArray = [dic objectForKey:@"results"];
              //TODO symbolize somehow empty array
-             if ([resultsArray count] > 0)
+             if ([resultsArray count] > 0){
                  errorcb([NSError errorWithDomain:@"io.ooni.api"
                                            code:100
                                        userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
                                                   }]);
+                 return;
+             }
              successcb([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
          }
     }];

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -120,7 +120,7 @@
          //TODO symbolize somehow empty array
          if ([resultsArray count] <= 0) {
              errorcb([NSError errorWithDomain:@"io.ooni.api"
-                                         code:JSON_EMPTY_CODE
+                                         code:ERR_JSON_EMPTY
                                      userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
                                                 }]);
              return;

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -101,12 +101,15 @@
     components.scheme = @"https";
     components.host = @"api.ooni.io";
     components.path = @"/api/v1/measurements";
-    if ([self.test_name isEqualToString:@"web_connectivity"])
-        components.query = [NSString stringWithFormat:@"report_id=%@&input=%@",
-                            self.report_id, self.url_id.url];
+    NSURLQueryItem *reportIdItem = [NSURLQueryItem queryItemWithName:@"report_id" value:self.report_id];
+
+    if ([self.test_name isEqualToString:@"web_connectivity"]){
+        NSURLQueryItem *urlItem = [NSURLQueryItem queryItemWithName:@"input" value:self.url_id.url];
+        components.queryItems = @[ reportIdItem, urlItem ];
+    }
     else
-        components.query = [NSString stringWithFormat:@"report_id=%@",
-                        self.report_id];
+        components.queryItems = @[ reportIdItem ];
+
     NSURL *url = components.URL;
     NSURLSessionDataTask *downloadTask = [[NSURLSession sharedSession]
      dataTaskWithURL:url

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -101,10 +101,14 @@
     components.scheme = @"https";
     components.host = @"api.ooni.io";
     components.path = @"/api/v1/measurements";
-    NSURLQueryItem *reportIdItem = [NSURLQueryItem queryItemWithName:@"report_id" value:self.report_id];
+    NSURLQueryItem *reportIdItem = [NSURLQueryItem
+                                    queryItemWithName:@"report_id"
+                                    value:self.report_id];
 
     if ([self.test_name isEqualToString:@"web_connectivity"]){
-        NSURLQueryItem *urlItem = [NSURLQueryItem queryItemWithName:@"input" value:self.url_id.url];
+        NSURLQueryItem *urlItem = [NSURLQueryItem
+                                   queryItemWithName:@"input"
+                                   value:self.url_id.url];
         components.queryItems = @[ reportIdItem, urlItem ];
     }
     else

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -108,28 +108,26 @@
     [[NSURLSession sharedSession]
      dataTaskWithURL:url
      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-         if (error != nil){
+         if (error != nil) {
              errorcb(error);
              return;
          }
-         else {
-             NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
-             if (error != nil){
-                 errorcb(error);
-                 return;
-             }
-             NSArray *resultsArray = [dic objectForKey:@"results"];
-             //TODO symbolize somehow empty array
-             if ([resultsArray count] > 0){
-                 errorcb([NSError errorWithDomain:@"io.ooni.api"
-                                           code:100
-                                       userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
-                                                  }]);
-                 return;
-             }
-             successcb([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
+         NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+         if (error != nil) {
+             errorcb(error);
+             return;
          }
-    }];
+         NSArray *resultsArray = [dic objectForKey:@"results"];
+         //TODO symbolize somehow empty array
+         if ([resultsArray count] <= 0) {
+             errorcb([NSError errorWithDomain:@"io.ooni.api"
+                                         code:100
+                                     userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
+                                                }]);
+             return;
+         }
+         successcb([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
+     }];
     [downloadTask resume];
 }
 

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -118,26 +118,35 @@
     NSURLSessionDataTask *downloadTask = [[NSURLSession sharedSession]
      dataTaskWithURL:url
      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-         if (error != nil) {
-             errorcb(error);
-             return;
-         }
-         NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
-         if (error != nil) {
-             errorcb(error);
-             return;
-         }
-         NSArray *resultsArray = [dic objectForKey:@"results"];
-         if ([resultsArray count] <= 0 || ![[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]) {
-             errorcb([NSError errorWithDomain:@"io.ooni.api"
-                                         code:ERR_JSON_EMPTY
-                                     userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
-                                                }]);
-             return;
-         }
-         successcb([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
+         [self getExplorerUrlCallback:data response:response error:error
+                          onSuccess:successcb onError:errorcb];
      }];
     [downloadTask resume];
 }
 
+- (void)getExplorerUrlCallback:(NSData *)data
+                    response:(NSURLResponse *)response
+                       error:(NSError *)error
+                   onSuccess:(void (^)(NSString*))successcb
+                     onError:(void (^)(NSError*))errorcb {
+    if (error != nil) {
+        errorcb(error);
+        return;
+    }
+    NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+    if (error != nil) {
+        errorcb(error);
+        return;
+    }
+    NSArray *resultsArray = [dic objectForKey:@"results"];
+    if ([resultsArray count] <= 0 || ![[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]) {
+        errorcb([NSError errorWithDomain:@"io.ooni.api"
+                                    code:ERR_JSON_EMPTY
+                                userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
+                                           }]);
+        return;
+    }
+    successcb([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
+
+}
 @end

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -117,7 +117,10 @@
              NSArray *resultsArray = [dic objectForKey:@"results"];
              //TODO symbolize somehow empty array
              if ([resultsArray count] == 0)
-                 error(nil);
+                 error([NSError errorWithDomain:@"io.ooni.api"
+                                           code:100
+                                       userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
+                                                  }];);
              success([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
          }
     }];

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -104,8 +104,7 @@
         [path appendString:[NSString stringWithFormat:@"&input=%@",
                             self.url_id.url]];
     NSURL *url = [NSURL URLWithString:path];
-    NSURLSessionDataTask *downloadTask =
-    [[NSURLSession sharedSession]
+    NSURLSessionDataTask *downloadTask = [[NSURLSession sharedSession]
      dataTaskWithURL:url
      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
          if (error != nil) {

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -108,7 +108,7 @@
     [[NSURLSession sharedSession]
      dataTaskWithURL:url
      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-         if (nserror != nil)
+         if (error != nil)
              errorcb(error);
          else {
              NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
@@ -116,11 +116,11 @@
                  errorcb(error);
              NSArray *resultsArray = [dic objectForKey:@"results"];
              //TODO symbolize somehow empty array
-             if ([resultsArray count] == 0)
+             if ([resultsArray count] > 0)
                  errorcb([NSError errorWithDomain:@"io.ooni.api"
                                            code:100
                                        userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
-                                                  }];);
+                                                  }]);
              successcb([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
          }
     }];

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -82,4 +82,24 @@
     [self remove];
 }
 
+- (void)getExplorerUrl:(void (^)(NSString *))measurement_url {
+    NSString *path = [NSString stringWithFormat:@"https://api.ooni.io/api/v1/measurements?report_id=%@&input=%@", self.report_id, self.url_id.url];
+    NSURL *url = [NSURL URLWithString:path];
+    NSURLSessionDataTask *downloadTask = [[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        if (!error) {
+            NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+            NSArray *resultsArray = [dic objectForKey:@"results"];
+            if ([resultsArray count] == 0)
+                measurement_url(nil);
+            measurement_url([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
+        }
+        else {
+            // Fail
+            measurement_url(nil);
+            NSLog(@"error : %@", error.description);
+        }
+    }];
+    [downloadTask resume];
+}
+
 @end

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -97,9 +97,17 @@
 }
 
 - (void)getExplorerUrl:(void (^)(NSString *))measurement_url {
-    NSString *path = [NSString stringWithFormat:@"https://api.ooni.io/api/v1/measurements?report_id=%@&input=%@", self.report_id, self.url_id.url];
+    NSLog(@"%@ getExplorerUrl",self.Id);
+    NSMutableString *path = [NSMutableString stringWithFormat:@"https://api.ooni.io/api/v1/measurements?report_id=%@",
+                      self.report_id];
+    if ([self.test_name isEqualToString:@"web_connectivity"])
+        [path appendString:[NSString stringWithFormat:@"&input=%@",
+                            self.url_id.url]];
     NSURL *url = [NSURL URLWithString:path];
-    NSURLSessionDataTask *downloadTask = [[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+    NSURLSessionDataTask *downloadTask =
+    [[NSURLSession sharedSession]
+     dataTaskWithURL:url
+     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (!error) {
             NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
             NSArray *resultsArray = [dic objectForKey:@"results"];

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -96,7 +96,7 @@
     [self remove];
 }
 
-- (void)getExplorerUrl:(void (^)(NSString *))measurement_url {
+-(void)getExplorerUrlSuccessCallback:(void (^)(NSString*))success errorCallback:(void (^)(NSError*))error {
     NSLog(@"%@ getExplorerUrl",self.Id);
     NSMutableString *path = [NSMutableString stringWithFormat:@"https://api.ooni.io/api/v1/measurements?report_id=%@",
                       self.report_id];
@@ -107,19 +107,19 @@
     NSURLSessionDataTask *downloadTask =
     [[NSURLSession sharedSession]
      dataTaskWithURL:url
-     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-        if (!error) {
-            NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
-            NSArray *resultsArray = [dic objectForKey:@"results"];
-            if ([resultsArray count] == 0)
-                measurement_url(nil);
-            measurement_url([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
-        }
-        else {
-            // Fail
-            measurement_url(nil);
-            NSLog(@"error : %@", error.description);
-        }
+     completionHandler:^(NSData *data, NSURLResponse *response, NSError *nserror) {
+         if (nserror != nil)
+             error(nserror);
+         else {
+             NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&nserror];
+             if (nserror != nil)
+                 error(nserror);
+             NSArray *resultsArray = [dic objectForKey:@"results"];
+             //TODO symbolize somehow empty array
+             if ([resultsArray count] == 0)
+                 error(nil);
+             success([[resultsArray objectAtIndex:0] objectForKey:@"measurement_url"]);
+         }
     }];
     [downloadTask resume];
 }

--- a/ooniprobe/Model/Database/Url.mm
+++ b/ooniprobe/Model/Database/Url.mm
@@ -31,6 +31,9 @@
 }
 
 + (Url*)checkExistingUrl:(NSString*)input categoryCode:(NSString*)categoryCode countryCode:(NSString*)countryCode{
+    if (input == nil) return nil;
+    if (categoryCode == nil) categoryCode = @"MISC";
+    if (countryCode == nil) countryCode = @"XX";
     Url *url = [self getUrl:input];
     if (url == nil){
         url = [[Url alloc] initWithUrl:input category:categoryCode country:countryCode];

--- a/ooniprobe/PrefixHeader.pch
+++ b/ooniprobe/PrefixHeader.pch
@@ -21,6 +21,7 @@
 #define SOFTWARE_NAME @"ooniprobe-ios"
 #define DEFAULT_TIMEOUT 30
 #define ERR_JSON_EMPTY 100
+#define ERR_NO_VALID_URLS 101
 
 #define color_base @"#0588cb"
 #define color_black @"#000000"

--- a/ooniprobe/PrefixHeader.pch
+++ b/ooniprobe/PrefixHeader.pch
@@ -20,6 +20,7 @@
 #define MANUAL_UPLOAD_POPUP @"upload_result_manually_popup"
 #define SOFTWARE_NAME @"ooniprobe-ios"
 #define DEFAULT_TIMEOUT 30
+#define JSON_EMPTY_CODE 100
 
 #define color_base @"#0588cb"
 #define color_black @"#000000"

--- a/ooniprobe/PrefixHeader.pch
+++ b/ooniprobe/PrefixHeader.pch
@@ -20,7 +20,7 @@
 #define MANUAL_UPLOAD_POPUP @"upload_result_manually_popup"
 #define SOFTWARE_NAME @"ooniprobe-ios"
 #define DEFAULT_TIMEOUT 30
-#define JSON_EMPTY_CODE 100
+#define ERR_JSON_EMPTY 100
 
 #define color_base @"#0588cb"
 #define color_black @"#000000"

--- a/ooniprobe/Test/Test/WebConnectivity.mm
+++ b/ooniprobe/Test/Test/WebConnectivity.mm
@@ -16,15 +16,12 @@
     if (self.inputs == nil || [self.inputs count] == 0){
         //Download urls and then alloc class
         [TestUtility downloadUrls:^(NSArray *urls) {
-            if (urls != nil && [urls count] > 0){
-                [self setUrls:urls];
-                [self setDefaultMaxRuntime];
-                [super runTest];
-            }
-            else {
-                [[NSNotificationCenter defaultCenter] postNotificationName:@"showError" object:nil];
-                [super testEnded];
-            }
+            [self setUrls:urls];
+            [self setDefaultMaxRuntime];
+            [super runTest];
+        } onError:^(NSError *error) {
+            [[NSNotificationCenter defaultCenter] postNotificationName:@"showError" object:nil];
+            [super testEnded];
         }];
     }
     else {

--- a/ooniprobe/Utility/TestUtility.h
+++ b/ooniprobe/Utility/TestUtility.h
@@ -13,7 +13,7 @@
 + (NSString*)getCategoryForTest:(NSString*)testName;
 + (UIColor*)getColorForTest:(NSString*)testName;
 + (UIColor*)getColorForTest:(NSString*)testName alpha:(CGFloat)alpha;
-+ (void)downloadUrls:(void (^)(NSArray *))completion;
++ (void)downloadUrls:(void (^)(NSArray*))successcb onError:(void (^)(NSError*))errorcb;
 + (void)removeFile:(NSString*)fileName;
 + (BOOL)fileExists:(NSString*)fileName;
 + (NSString*)getUTF8FileContent:(NSString*)fileName;

--- a/ooniprobe/Utility/TestUtility.mm
+++ b/ooniprobe/Utility/TestUtility.mm
@@ -83,11 +83,15 @@
     components.scheme = @"https";
     components.host = @"orchestrate.ooni.io";
     components.path = @"/api/v1/test-list/urls";
-    NSURLQueryItem *ccItem = [NSURLQueryItem queryItemWithName:@"country_code" value:cc];
+    NSURLQueryItem *ccItem = [NSURLQueryItem
+                              queryItemWithName:@"country_code"
+                              value:cc];
     if ([[SettingsUtility getSitesCategoriesDisabled] count] > 0){
         NSMutableArray *categories = [NSMutableArray arrayWithArray:[SettingsUtility getSitesCategories]];
         [categories removeObjectsInArray:[SettingsUtility getSitesCategoriesDisabled]];
-        NSURLQueryItem *categoriesItem = [NSURLQueryItem queryItemWithName:@"category_codes" value:[categories componentsJoinedByString:@","]];
+        NSURLQueryItem *categoriesItem = [NSURLQueryItem
+                                          queryItemWithName:@"category_codes"
+                                          value:[categories componentsJoinedByString:@","]];
         components.queryItems = @[ ccItem, categoriesItem ];
     }
     else {

--- a/ooniprobe/Utility/TestUtility.mm
+++ b/ooniprobe/Utility/TestUtility.mm
@@ -107,7 +107,10 @@
              [urls addObject:url.url];
          }
          if ([urls count] == 0){
-             errorcb(error);
+             errorcb([NSError errorWithDomain:@"io.ooni.api"
+                                         code:ERR_JSON_EMPTY
+                                     userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
+                                                }]);
              return;
          }
          successcb(urls);

--- a/ooniprobe/Utility/TestUtility.mm
+++ b/ooniprobe/Utility/TestUtility.mm
@@ -72,6 +72,7 @@
     return [UIColor colorWithRGBHexString:color_blue5 alpha:alpha];
 }
 
+// TODO(lorenzoPrimi): I would move this function into another class who handles all API Calls
 + (void)downloadUrls:(void (^)(NSArray*))successcb onError:(void (^)(NSError*))errorcb {
     MKGeoIPLookupTask *task = [[MKGeoIPLookupTask alloc] init];
     [task setTimeout:DEFAULT_TIMEOUT];

--- a/ooniprobe/Utility/TestUtility.mm
+++ b/ooniprobe/Utility/TestUtility.mm
@@ -121,8 +121,8 @@
          }
          if ([urls count] == 0){
              errorcb([NSError errorWithDomain:@"io.ooni.orchestrate"
-                                         code:ERR_JSON_EMPTY
-                                     userInfo:@{NSLocalizedDescriptionKey:@"Error.JsonEmpty"
+                                         code:ERR_NO_VALID_URLS
+                                     userInfo:@{NSLocalizedDescriptionKey:@"Error.NoValidUrls"
                                                 }]);
              return;
          }

--- a/ooniprobe/Utility/TestUtility.mm
+++ b/ooniprobe/Utility/TestUtility.mm
@@ -86,7 +86,10 @@
         path = [NSString stringWithFormat:@"%@&category_codes=%@", path, [categories componentsJoinedByString:@","]];
     }
     NSURL *url = [NSURL URLWithString:path];
-    NSURLSessionDataTask *downloadTask = [[NSURLSession sharedSession] dataTaskWithURL:url completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+    NSURLSessionDataTask *downloadTask =
+    [[NSURLSession sharedSession]
+     dataTaskWithURL:url
+     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (!error) {
             NSDictionary *dic = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
             NSArray *urlsArray = [dic objectForKey:@"results"];

--- a/ooniprobe/Utility/TestUtility.mm
+++ b/ooniprobe/Utility/TestUtility.mm
@@ -86,8 +86,7 @@
         path = [NSString stringWithFormat:@"%@&category_codes=%@", path, [categories componentsJoinedByString:@","]];
     }
     NSURL *url = [NSURL URLWithString:path];
-    NSURLSessionDataTask *downloadTask =
-    [[NSURLSession sharedSession]
+    NSURLSessionDataTask *downloadTask = [[NSURLSession sharedSession]
      dataTaskWithURL:url
      completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         if (!error) {


### PR DESCRIPTION
This should do the trick, I just don't understand why we need the URL. 
Can't we call this function for non-webconnectivity tests?
