### PR TITLE
Implement faster measurement resubmission

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '9.0'
 # ignore all warnings from all pods
 inhibit_all_warnings!
 target 'ooniprobe' do
-    pod 'mkall', :git => 'https://github.com/measurement-kit/mkall-ios.git', :tag => 'v0.5.5'
+    pod 'mkall', :git => 'https://github.com/measurement-kit/mkall-ios.git', :tag => 'v0.6.0'
     pod 'Toast', '~> 4.0.0'
     pod 'Fabric'
     pod 'Crashlytics'

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '9.0'
 # ignore all warnings from all pods
 inhibit_all_warnings!
 target 'ooniprobe' do
-    pod 'mkall', :git => 'https://github.com/measurement-kit/mkall-ios.git', :tag => 'v0.5.2'
+    pod 'mkall', :git => 'https://github.com/measurement-kit/mkall-ios.git', :tag => 'v0.5.5'
     pod 'Toast', '~> 4.0.0'
     pod 'Fabric'
     pod 'Crashlytics'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
-  - Crashlytics (3.13.1):
-    - Fabric (~> 1.10.1)
+  - Crashlytics (3.13.4):
+    - Fabric (~> 1.10.2)
   - DateTools (2.0.0)
   - DZNEmptyDataSet (1.8.1)
-  - Fabric (1.10.1)
+  - Fabric (1.10.2)
   - lottie-ios (2.5.3)
   - MBProgressHUD (1.1.0)
-  - mkall (0.5.2)
+  - mkall (0.5.5)
   - MKDropdownMenu (1.4)
   - OCMapper (2.0)
   - RHMarkdownLabel (0.0.1):
@@ -24,7 +24,7 @@ DEPENDENCIES:
   - Fabric
   - lottie-ios (= 2.5.3)
   - MBProgressHUD
-  - mkall (from `https://github.com/measurement-kit/mkall-ios.git`, tag `v0.5.2`)
+  - mkall (from `https://github.com/measurement-kit/mkall-ios.git`, tag `v0.5.5`)
   - MKDropdownMenu
   - OCMapper (= 2.0)
   - RHMarkdownLabel
@@ -49,7 +49,7 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   mkall:
     :git: https://github.com/measurement-kit/mkall-ios.git
-    :tag: v0.5.2
+    :tag: v0.5.5
   SharkORM:
     :git: https://github.com/sharksync/sharkorm
     :tag: v2.3.67
@@ -57,19 +57,19 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   mkall:
     :git: https://github.com/measurement-kit/mkall-ios.git
-    :tag: v0.5.2
+    :tag: v0.5.5
   SharkORM:
     :git: https://github.com/sharksync/sharkorm
     :tag: v2.3.67
 
 SPEC CHECKSUMS:
-  Crashlytics: 5aa8e90dcbf2f34898b4f5a0037787531246cca0
+  Crashlytics: 2dfd686bcb918dc10ee0e76f7f853fe42c7bd552
   DateTools: 933ac9c490f21f92127cf690ccd8c397e0126caf
   DZNEmptyDataSet: 9525833b9e68ac21c30253e1d3d7076cc828eaa7
-  Fabric: f6f21452846788bb44595d73e9909d79d328e617
+  Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
   lottie-ios: a50d5c0160425cd4b01b852bb9578963e6d92d31
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
-  mkall: 1b0b1eac93d17ac292e93d8db91ed0bf3c01073e
+  mkall: afb9cf68d4a3b8d91a251012b9a5222e99f18472
   MKDropdownMenu: 269df4a41d21a1db684ce8bc709befe419fc5bae
   OCMapper: 9b4d542543794c42adc01f1493d894f53e193cb0
   RHMarkdownLabel: 81d6772768e621be57302b7fd5212ad4f78fb0bd
@@ -78,6 +78,6 @@ SPEC CHECKSUMS:
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: b55479f3936580bbec2d6e86dc4861eabbe98da4
+PODFILE CHECKSUM: 8c7de280d1f845a3514ed8b862f913708b2ec7ef
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.7.5

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -6,7 +6,7 @@ PODS:
   - Fabric (1.10.2)
   - lottie-ios (2.5.3)
   - MBProgressHUD (1.1.0)
-  - mkall (0.5.5)
+  - mkall (0.6.0)
   - MKDropdownMenu (1.4)
   - OCMapper (2.0)
   - RHMarkdownLabel (0.0.1):
@@ -24,7 +24,7 @@ DEPENDENCIES:
   - Fabric
   - lottie-ios (= 2.5.3)
   - MBProgressHUD
-  - mkall (from `https://github.com/measurement-kit/mkall-ios.git`, tag `v0.5.5`)
+  - mkall (from `https://github.com/measurement-kit/mkall-ios.git`, tag `v0.6.0`)
   - MKDropdownMenu
   - OCMapper (= 2.0)
   - RHMarkdownLabel
@@ -49,7 +49,7 @@ SPEC REPOS:
 EXTERNAL SOURCES:
   mkall:
     :git: https://github.com/measurement-kit/mkall-ios.git
-    :tag: v0.5.5
+    :tag: v0.6.0
   SharkORM:
     :git: https://github.com/sharksync/sharkorm
     :tag: v2.3.67
@@ -57,7 +57,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   mkall:
     :git: https://github.com/measurement-kit/mkall-ios.git
-    :tag: v0.5.5
+    :tag: v0.6.0
   SharkORM:
     :git: https://github.com/sharksync/sharkorm
     :tag: v2.3.67
@@ -69,7 +69,7 @@ SPEC CHECKSUMS:
   Fabric: 706c8b8098fff96c33c0db69cbf81f9c551d0d74
   lottie-ios: a50d5c0160425cd4b01b852bb9578963e6d92d31
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
-  mkall: afb9cf68d4a3b8d91a251012b9a5222e99f18472
+  mkall: 9e83207806b4d1553d840e01df31b6698aaf039f
   MKDropdownMenu: 269df4a41d21a1db684ce8bc709befe419fc5bae
   OCMapper: 9b4d542543794c42adc01f1493d894f53e193cb0
   RHMarkdownLabel: 81d6772768e621be57302b7fd5212ad4f78fb0bd
@@ -78,6 +78,6 @@ SPEC CHECKSUMS:
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: 8c7de280d1f845a3514ed8b862f913708b2ec7ef
+PODFILE CHECKSUM: b6e2473b62815be1a0f262a0ad491eae3ffed197
 
 COCOAPODS: 1.7.5

--- a/ooniprobe.xcodeproj/project.pbxproj
+++ b/ooniprobe.xcodeproj/project.pbxproj
@@ -1110,15 +1110,11 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-ooniprobe/Pods-ooniprobe-frameworks.sh",
 				"${PODS_ROOT}/mkall/mkall.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/mkall.framework",
 			);

--- a/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
+++ b/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
@@ -123,7 +123,6 @@
             reporterTask:(MKReporterTask *)task {
     NSString *content = [TestUtility getUTF8FileContent:[measurement getReportFile]];
     NSUInteger bytes = [content lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
-    //[task setTimeout:[TestUtility makeTimeout:bytes]]; /* XXX */
     MKReporterResults *results = [
       task submit:content uploadTimeout:[TestUtility makeTimeout:bytes]];
     if ([results good]){

--- a/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
+++ b/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
@@ -2,7 +2,7 @@
 #import "MessageUtility.h"
 #import <QuartzCore/QuartzCore.h>
 #import "SettingsUtility.h"
-#import <mkall/MKCollector.h>
+#import <mkall/MKReporter.h>
 #import "TestUtility.h"
 #import "MBProgressHUD.h"
 #import "VersionUtility.h"
@@ -87,6 +87,9 @@
         float progress = 0.0f;
         //The progress should consider the array size - the idx of first element to actually be uploaded
         float measurementValue = 1.0/([notUploaded count] - i);
+        MKReporterTask *task = [[MKReporterTask alloc]
+          initWithSoftwareName:SOFTWARE_NAME
+          softwareVersion:[VersionUtility get_software_version]];
         while (i < [notUploaded count]){
             Measurement *currentMeasurement = [notUploaded objectAtIndex:i];
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -94,7 +97,7 @@
                 NSLocalizedFormatString(@"Modal.ResultsNotUploaded.Uploading",
                                         [NSString stringWithFormat:@"%ld/%ld", i+1, ([notUploaded count] - idx)]);
             });
-            if (![self uploadMeasurement:currentMeasurement]){
+            if (![self uploadMeasurement:currentMeasurement reporterTask:task]){
                 dispatch_async(dispatch_get_main_queue(), ^{
                     [self showRetryPopup:notUploaded startAt:i];
                 });
@@ -116,16 +119,13 @@
     });
 }
 
--(BOOL)uploadMeasurement:(Measurement*)measurement{
+-(BOOL)uploadMeasurement:(Measurement*)measurement
+            reporterTask:(MKReporterTask *)task {
     NSString *content = [TestUtility getUTF8FileContent:[measurement getReportFile]];
     NSUInteger bytes = [content lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
-    MKCollectorResubmitTask *task = [[MKCollectorResubmitTask alloc]
-                                     initWithSerializedMeasurement:content
-                                     softwareName:SOFTWARE_NAME
-                                     softwareVersion:[VersionUtility get_software_version]
-                                     ];
-    [task setTimeout:[TestUtility makeTimeout:bytes]];
-    MKCollectorResubmitResults *results = [task perform];
+    //[task setTimeout:[TestUtility makeTimeout:bytes]]; /* XXX */
+    MKReporterResults *results = [
+      task submit:content uploadTimeout:[TestUtility makeTimeout:bytes]];
     if ([results good]){
         //save updated file
         [TestUtility writeString:[results updatedSerializedMeasurement] toFile:[TestUtility getFileNamed:[measurement getReportFile]]];


### PR DESCRIPTION
Part of https://github.com/ooni/probe/issues/861.

Uses https://github.com/measurement-kit/mkcollector/pull/25 and https://github.com/measurement-kit/mkall-ios/pull/25 to make the act of resubmitting really faster.

This is bundled with https://github.com/measurement-kit/mkall-ios/releases/tag/v0.5.5 that contains also reliability fixes, including a fix to make sure we really deallocate ObjectiveC objects context.
