### PR TITLE
Copy explorer url

### DIFF
--- a/ooniprobe/View/TestResults/Details/TestDetailsViewController.h
+++ b/ooniprobe/View/TestResults/Details/TestDetailsViewController.h
@@ -8,6 +8,7 @@
 
 @interface TestDetailsViewController : UIViewController {
     NSString *segueType;
+    BOOL isInExplorer;
 }
 
 @property (nonatomic, strong) Result *result;

--- a/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
+++ b/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
@@ -31,7 +31,7 @@
             [TestUtility removeFile:[self.measurement getReportFile]];
             [TestUtility removeFile:[self.measurement getLogFile]];
         } onError:^(NSError *error) {
-            /* NOTHING */
+            isInExplorer = FALSE;
         }];
     }
 }
@@ -84,7 +84,14 @@
     if ([self.measurement.test_name isEqualToString:@"web_connectivity"])
         [link appendFormat:@"?input=%@", self.measurement.url_id.url];
     pasteboard.string = link;
-    [MessageUtility showToast:NSLocalizedString(@"Toast.CopiedToClipboard", nil) inView:self.view];
+    if (isInExplorer)
+        [MessageUtility showToast:NSLocalizedString(@"Toast.CopiedToClipboard", nil) inView:self.view];
+    else
+        [MessageUtility showToast:
+         [NSString stringWithFormat:@"%@\n%@",
+          NSLocalizedString(@"Toast.CopiedToClipboard", nil),
+          NSLocalizedString(@"Toast.WillBeAvailable", nil)]
+          inView:self.view];
 }
 
 #pragma mark - Navigation

--- a/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
+++ b/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
@@ -46,6 +46,13 @@
                                    handler:^(UIAlertAction * action) {
                                        [self viewLogs];
                                    }];
+    UIAlertAction* explorerButton = [UIAlertAction
+                                    actionWithTitle:NSLocalizedString(@"TestResults.Details.CopyExplorerURL", nil)
+                                    style:UIAlertActionStyleDefault
+                                    handler:^(UIAlertAction * action) {
+                                        [self copyExplorerUrl];
+                                    }];
+
     NSArray *buttons = [NSArray arrayWithObjects:rawDataButton, logButton, nil];
     [MessageUtility alertWithTitle:nil message:nil buttons:buttons inView:self];
 
@@ -59,6 +66,15 @@
 - (IBAction)rawData{
     segueType = @"json";
     [self performSegueWithIdentifier:@"toViewLog" sender:self];
+}
+
+-(IBAction)copyExplorerUrl{
+    UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
+    NSMutableString *link = [NSMutableString stringWithFormat:@"https://explorer.ooni.io/measurement/%@", self.measurement.report_id];
+    if ([self.measurement.test_name isEqualToString:@"web_connectivity"])
+        [link appendFormat:@"?input=%@", self.measurement.url_id.url];
+    pasteboard.string = link;
+    [MessageUtility showToast:NSLocalizedString(@"Toast.CopiedToClipboard", nil) inView:self.view];
 }
 
 #pragma mark - Navigation

--- a/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
+++ b/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
@@ -24,8 +24,10 @@
     //assign button to navigationbar
     self.navigationItem.rightBarButtonItem = moreButton;
     [self reloadFooter];
+    isInExplorer = ![self.measurement hasReportFile];
     if ([self.measurement hasReportFile]){
         [self.measurement getExplorerUrl:^(NSString *measurement_url){
+            isInExplorer = TRUE;
             [TestUtility removeFile:[self.measurement getReportFile]];
             [TestUtility removeFile:[self.measurement getLogFile]];
         } onError:^(NSError *error) {

--- a/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
+++ b/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
@@ -24,6 +24,14 @@
     //assign button to navigationbar
     self.navigationItem.rightBarButtonItem = moreButton;
     [self reloadFooter];
+    if ([self.measurement hasReportFile]){
+        [self.measurement getExplorerUrl:^(NSString *measurement_url){
+            [TestUtility removeFile:[self.measurement getReportFile]];
+            [TestUtility removeFile:[self.measurement getLogFile]];
+        } onError:^(NSError *error) {
+            /* NOTHING */
+        }];
+    }
 }
 
 - (void)willMoveToParentViewController:(UIViewController *)parent {


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/856

## Proposed Changes

  - Calling the measurements url every time opening this screen (if json file is on disk) and delete it when published. Having in this case the “status” of the publishing of the measurement in this screen
  - Showing different messages if the measurement has been published or not
  - Copies the url to clipboard
