### PR TITLE
View Controller Default Presentation Style (iOS 13)

### DIFF
--- a/ooniprobe/Storyboards/Dashboard.storyboard
+++ b/ooniprobe/Storyboards/Dashboard.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina5_9" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -164,7 +162,7 @@
         <!--Test Running View Controller-->
         <scene sceneID="o6C-L4-nq5">
             <objects>
-                <viewController storyboardIdentifier="test_running" id="4q0-13-6dh" customClass="TestRunningViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="test_running" modalPresentationStyle="fullScreen" id="4q0-13-6dh" customClass="TestRunningViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="tHi-Ui-7Hp"/>
                         <viewControllerLayoutGuide type="bottom" id="iDt-w7-KI4"/>


### PR DESCRIPTION
The test run screen in iOS 13 was not full screen and there is the possibility to close it (where there shouldn't be)
This is due to the new presentation style of iOS 13, check "View Controller Default Presentation Style" at https://medium.com/better-programming/ios-13-checklist-for-developers-ef47e413aad2

I managed to fix it directly in the storyboard without having to touch the code with this option https://stackoverflow.com/a/58067559/1187692

This must be merged in 2.2.0

![IMG_0168](https://user-images.githubusercontent.com/1616097/66264672-847d5980-e83c-11e9-8ffb-620714f3cc81.PNG)
