### PR TITLE
Load text smoothly

### DIFF
--- a/ooniprobe/View/TestResults/LogViewController.h
+++ b/ooniprobe/View/TestResults/LogViewController.h
@@ -5,6 +5,7 @@
 
 @property (nonatomic, strong) NSString *type;
 @property (nonatomic, strong) Measurement *measurement;
+@property (nonatomic, strong) NSString *text;
 @property (nonatomic, strong) IBOutlet UITextView *textView;
 
 @end

--- a/ooniprobe/View/TestResults/LogViewController.m
+++ b/ooniprobe/View/TestResults/LogViewController.m
@@ -20,7 +20,7 @@
     if ([self.type isEqualToString:@"log"]){
         NSString *fileName = [self.measurement getLogFile];
         self.text = [TestUtility getUTF8FileContent:fileName];
-        if (content != nil) {
+        if (self.text != nil) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 [self.textView setText:self.text];
             });

--- a/ooniprobe/View/TestResults/LogViewController.m
+++ b/ooniprobe/View/TestResults/LogViewController.m
@@ -16,11 +16,14 @@
                                             style:UIBarButtonItemStylePlain
                                             target:self
                                             action:@selector(copy_clipboard:)];
+    [self.textView setText:NSLocalizedString(@"OONIBrowser.Loading", nil)];
     if ([self.type isEqualToString:@"log"]){
         NSString *fileName = [self.measurement getLogFile];
-        NSString *content = [TestUtility getUTF8FileContent:fileName];
+        self.text = [TestUtility getUTF8FileContent:fileName];
         if (content != nil) {
-            [self.textView setText:content];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self.textView setText:self.text];
+            });
         }
         else {
             //Show Log not found alert, go back on OK.
@@ -42,8 +45,10 @@
         NSString *fileName = [self.measurement getReportFile];
         NSString *content = [TestUtility getUTF8FileContent:fileName];
         if (content != nil) {
-            NSString *prettyPrintedJson = [self prettyPrintedJsonfromUTF8String:content];
-            [self.textView setText:prettyPrintedJson];
+            self.text = [self prettyPrintedJsonfromUTF8String:content];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self.textView setText:self.text];
+            });
         }
         else {
             //Download content from web
@@ -55,8 +60,10 @@
                                 onSuccess:^(NSDictionary *measurementJson) {
                                     dispatch_async(dispatch_get_main_queue(), ^{
                                     [MBProgressHUD hideHUDForView:self.navigationController.view animated:YES];
-                                        NSString *prettyPrintedJson = [self prettyPrintedJsonfromObject:measurementJson];
-                                        [self.textView setText:prettyPrintedJson];
+                                        self.text = [self prettyPrintedJsonfromObject:measurementJson];
+                                        dispatch_async(dispatch_get_main_queue(), ^{
+                                            [self.textView setText:self.text];
+                                        });
                                     });
                                 } onError:^(NSError *error) {
                                     [self onError:error];
@@ -122,7 +129,7 @@
 
 -(IBAction)copy_clipboard:(id)sender{
     UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
-    pasteboard.string = self.textView.text;
+    pasteboard.string = self.text;
     [MessageUtility showToast:NSLocalizedString(@"Toast.CopiedToClipboard", nil) inView:self.view];
 }
 


### PR DESCRIPTION
Fixes https://github.com/ooni/probe-android/issues/229 and https://github.com/ooni/probe/issues/865

## Proposed Changes

  - Saving the text in a strong variable `self.text` so we don't have to read the TextView when copying to clipboard
  - Write on the TextView on UIThread
  - Initialise the `TextView` with a string saying "Loading..."
