### PR TITLE
Test running screen improve during URLs download

### DIFF
--- a/ooniprobe/Base.lproj/Localizable.strings
+++ b/ooniprobe/Base.lproj/Localizable.strings
@@ -42,6 +42,7 @@
 "Dashboard.Running.PreparingTest" = "Preparing test";
 "Dashboard.Running.ShowLog" = "Show Log";
 "Dashboard.Running.CloseLog" = "Close Log";
+"Dashboard.Running.CalculatingETA" = "Calculating ETA";
 "Dashboard.Card.Subtitle" = "Tap card for more";
 "Dashboard.Card.Seconds" = "~%@s";
 "Dashboard.Websites.Card.Description" = "Test the blocking of websites";

--- a/ooniprobe/View/RunTest/TestRunningViewController.mm
+++ b/ooniprobe/View/RunTest/TestRunningViewController.mm
@@ -20,6 +20,7 @@
     [self.runningTestsLabel setText:NSLocalizedString(@"Dashboard.Running.Running", nil)];
     [self.logLabel setText:@""];
     [self.etaLabel setText:NSLocalizedString(@"Dashboard.Running.EstimatedTimeLeft", nil)];
+    [self.timeLabel setText:NSLocalizedString(@"Dashboard.Running.CalculatingETA", nil)];
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(updateProgress:) name:@"updateProgress" object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(setRuntime) name:@"updateRuntime" object:nil];


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/1020

## Proposed Changes

  - Adding `Calculate ETA` string on time remaining on start