### PR TITLE
Sort results in the order they ran

### DIFF
--- a/ooniprobe/Model/Database/Result.h
+++ b/ooniprobe/Model/Database/Result.h
@@ -37,6 +37,7 @@
 -(void)save;
 -(Measurement*)getMeasurement:(NSString*)name;
 -(SRKResultSet*)measurements;
+-(SRKResultSet*)measurementsSorted;
 -(SRKResultSet*)allmeasurements;
 -(NSString*)getLogFile:(NSString*)test_name;
 -(void)deleteObject;

--- a/ooniprobe/Model/Database/Result.mm
+++ b/ooniprobe/Model/Database/Result.mm
@@ -10,6 +10,15 @@
 
 - (SRKResultSet*)measurements {
     //Not showing the re_run measurements
+    return [[[[Measurement query]
+               where:@"result_id = ? AND is_rerun = 0 AND is_done = 1"
+               parameters:@[self]]
+               order:@"Id"]
+               fetch];
+}
+
+- (SRKResultSet*)measurementsSorted {
+    //Not showing the re_run measurements
     return [[[[[[Measurement query]
                where:@"result_id = ? AND is_rerun = 0 AND is_done = 1"
                parameters:@[self]]
@@ -18,6 +27,7 @@
                order:@"Id"]
                fetch];
 }
+
 
 - (SRKResultSet*)allmeasurements {
     return [[[[Measurement query] where:@"result_id = ?" parameters:@[self]] orderByDescending:@"Id"] fetch];

--- a/ooniprobe/View/TestResults/TestSummaryViewController.m
+++ b/ooniprobe/View/TestResults/TestSummaryViewController.m
@@ -48,7 +48,10 @@
 }
 
 -(void)reloadMeasurements{
-    self.measurements = result.measurements;
+    if ([result.test_group_name isEqualToString:@"websites"])
+        self.measurements = result.measurementsSorted;
+    else
+        self.measurements = result.measurements;
     dispatch_async(dispatch_get_main_queue(), ^{
         if ([result isEveryMeasurementUploaded]){
             self.tableFooterConstraint.constant = -45;


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/1153

A new method measurementsSorted has been added that is gonna be used only when displaying website result rows.

