### PR TITLE
Sequence tests using a run queue

### DIFF
--- a/ooniprobe/Test/Suite/AbstractSuite.mm
+++ b/ooniprobe/Test/Suite/AbstractSuite.mm
@@ -29,10 +29,15 @@
         [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
         self.backgroundTask = UIBackgroundTaskInvalid;
     }];
+    int i = 0;
     for (AbstractTest *current in [self getTestList]){
         [current setDelegate:self];
         [current setResult:self.result];
-        [current runTest];
+        //Run test one a second after another to ensure they run in order
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, i * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+            [current runTest];
+        });
+        i++;
     }
 }
 

--- a/ooniprobe/Test/Suite/AbstractSuite.mm
+++ b/ooniprobe/Test/Suite/AbstractSuite.mm
@@ -25,18 +25,16 @@
 
 -(void)runTestSuite {
     [self newResult];
+    dispatch_queue_t serialQueue = dispatch_queue_create("org.openobservatory.queue", DISPATCH_QUEUE_SERIAL);
     self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
         [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
         self.backgroundTask = UIBackgroundTaskInvalid;
     }];
-    dispatch_queue_t serialQueue = dispatch_queue_create("org.openobservatory.queue", DISPATCH_QUEUE_SERIAL);
     for (AbstractTest *current in [self getTestList]){
         [current setDelegate:self];
+        [current setSerialQueue:serialQueue];
         [current setResult:self.result];
-        //Run test one after another to ensure they run in order
-        dispatch_async(serialQueue, ^{
-            [current runTest];
-        });
+        [current runTest];
     }
 }
 

--- a/ooniprobe/Test/Suite/AbstractSuite.mm
+++ b/ooniprobe/Test/Suite/AbstractSuite.mm
@@ -29,11 +29,12 @@
         [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
         self.backgroundTask = UIBackgroundTaskInvalid;
     }];
+    dispatch_queue_t serialQueue = dispatch_queue_create("org.openobservatory.queue", DISPATCH_QUEUE_SERIAL);
     for (AbstractTest *current in [self getTestList]){
         [current setDelegate:self];
         [current setResult:self.result];
         //Run test one after another to ensure they run in order
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(serialQueue, ^{
             [current runTest];
         });
     }

--- a/ooniprobe/Test/Suite/AbstractSuite.mm
+++ b/ooniprobe/Test/Suite/AbstractSuite.mm
@@ -29,15 +29,13 @@
         [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
         self.backgroundTask = UIBackgroundTaskInvalid;
     }];
-    int i = 0;
     for (AbstractTest *current in [self getTestList]){
         [current setDelegate:self];
         [current setResult:self.result];
-        //Run test one a second after another to ensure they run in order
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, i * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        //Run test one after another to ensure they run in order
+        dispatch_async(dispatch_get_main_queue(), ^{
             [current runTest];
         });
-        i++;
     }
 }
 

--- a/ooniprobe/Test/Test/AbstractTest.h
+++ b/ooniprobe/Test/Test/AbstractTest.h
@@ -24,6 +24,8 @@
 @property id<MKNetworkTestDelegate> delegate;
 @property Settings *settings;
 @property BOOL annotation;
+@property dispatch_queue_t serialQueue;
+
 -(id)initTest:(NSString*)testName;
 -(Measurement*)createMeasurementObject;
 -(void)onEntry:(JsonResult*)json obj:(Measurement*)measurement;

--- a/ooniprobe/Test/Test/AbstractTest.mm
+++ b/ooniprobe/Test/Test/AbstractTest.mm
@@ -63,8 +63,7 @@
         [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
         self.backgroundTask = UIBackgroundTaskInvalid;
     }];
-    dispatch_async(
-                   dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_async(_serialQueue, ^{
                        MKAsyncTask *task = [MKAsyncTask start:settings];
                        while (![task done]){
                            // Extract an event from the task queue and unmarshal it.


### PR DESCRIPTION
I noticed that some times even if I run the test in a fixed order:
```
    "<NdtTest: 0x6000022ec050>",
    "<Dash: 0x6000022ec0f0>",
    "<HttpInvalidRequestLine: 0x6000022ec370>",
    "<HttpHeaderFieldManipulation: 0x6000022ec410>"
```
The HIRL runs before Dash or any other random order.

Used the new queue system and worked 10/10 on Performance and 10/100 on IM tests