### PR TITLE
Remove logs more effectively on app start

### DIFF
--- a/ooniprobe/AppDelegate.mm
+++ b/ooniprobe/AppDelegate.mm
@@ -172,6 +172,7 @@
         [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"notifications_enabled"];
     if ([TestUtility canCallDeleteJson])
         [TestUtility deleteUploadedJsons];
+    [TestUtility deleteOldLogs];
 }
 
 - (void)applicationWillTerminate:(UIApplication *)application {

--- a/ooniprobe/Model/Database/Measurement.h
+++ b/ooniprobe/Model/Database/Measurement.h
@@ -29,6 +29,7 @@
 
 +(SRKResultSet*)notUploadedMeasurements;
 +(NSArray*)measurementsWithJson;
++ (NSArray*)measurementsWithLog;
 -(BOOL)hasReportFile;
 -(BOOL)hasLogFile;
 -(NSString*)getReportFile;

--- a/ooniprobe/Model/Database/Measurement.mm
+++ b/ooniprobe/Model/Database/Measurement.mm
@@ -26,6 +26,16 @@
     return measurementsJson;
 }
 
++ (NSArray*)measurementsWithLog {
+    NSMutableArray *measurementsLog = [NSMutableArray new];
+    SRKResultSet* results = [[[Measurement query] where:BASIC_QUERY] fetch];
+    for (Measurement *measurement in results){
+        if ([measurement hasLogFile])
+            [measurementsLog addObject:measurement];
+    }
+    return measurementsLog;
+}
+
 /*
     Three scenarios:
     I'm running the test, I start the empty summary, I add stuff and save

--- a/ooniprobe/Model/Database/Result.h
+++ b/ooniprobe/Model/Database/Result.h
@@ -2,8 +2,9 @@
 #import <SharkORM/SharkORM.h>
 #import "JsonResult.h"
 #import "Measurement.h"
-#define UPLOADED_QUERY @"is_failed = 0 AND is_rerun = 0 AND is_done = 1 AND (is_uploaded = 1 || report_id IS NOT NULL)"
-#define NOT_UPLOADED_QUERY @"is_failed = 0 AND is_rerun = 0 AND is_done = 1 AND (is_uploaded = 0 || report_id IS NULL)"
+#define BASIC_QUERY @"is_failed = 0 AND is_rerun = 0 AND is_done = 1"
+#define UPLOADED_QUERY (BASIC_QUERY @"AND (is_uploaded = 1 || report_id IS NOT NULL)")
+#define NOT_UPLOADED_QUERY (BASIC_QUERY @"AND (is_uploaded = 0 || report_id IS NULL)")
 
 /// Results contains the results of a test suite (e.g. Instant messaging).
 @interface Result : SRKObject

--- a/ooniprobe/Model/Database/Result.h
+++ b/ooniprobe/Model/Database/Result.h
@@ -3,8 +3,8 @@
 #import "JsonResult.h"
 #import "Measurement.h"
 #define BASIC_QUERY @"is_failed = 0 AND is_rerun = 0 AND is_done = 1"
-#define UPLOADED_QUERY (BASIC_QUERY @"AND (is_uploaded = 1 || report_id IS NOT NULL)")
-#define NOT_UPLOADED_QUERY (BASIC_QUERY @"AND (is_uploaded = 0 || report_id IS NULL)")
+#define UPLOADED_QUERY [NSString stringWithFormat:@"%@ AND (is_uploaded = 1 || report_id IS NOT NULL)", BASIC_QUERY]
+#define NOT_UPLOADED_QUERY [NSString stringWithFormat:@"%@ AND (is_uploaded = 0 || report_id IS NULL)", BASIC_QUERY]
 
 /// Results contains the results of a test suite (e.g. Instant messaging).
 @interface Result : SRKObject

--- a/ooniprobe/Utility/TestUtility.h
+++ b/ooniprobe/Utility/TestUtility.h
@@ -17,6 +17,7 @@
 + (UIColor*)getGradientColorForTest:(NSString*)testName;
 + (void)deleteUploadedJsonsWithMeasurementRemover:(void (^)(Measurement *))remover;
 + (void)deleteUploadedJsons;
++ (void)deleteOldLogs;
 + (void)removeLogAfterAWeek:(Measurement*)measurement;
 + (BOOL)canCallDeleteJson;
 + (BOOL)removeFile:(NSString*)fileName;

--- a/ooniprobe/Utility/TestUtility.mm
+++ b/ooniprobe/Utility/TestUtility.mm
@@ -121,10 +121,15 @@
 + (void)deleteUploadedJsons{
     [self deleteUploadedJsonsWithMeasurementRemover:^(Measurement *measurement) {
         [TestUtility removeFile:[measurement getReportFile]];
-        [TestUtility removeLogAfterAWeek:measurement];
     }];
     [[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:delete_json_key];
     [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
++ (void)deleteOldLogs{
+    for (Measurement *measurement in [Measurement measurementsWithLog]) {
+        [TestUtility removeLogAfterAWeek:measurement];
+    }
 }
 
 + (void)removeLogAfterAWeek:(Measurement*)measurement{

--- a/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
+++ b/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
@@ -29,7 +29,6 @@
         [self.measurement getExplorerUrl:^(NSString *measurement_url){
             isInExplorer = TRUE;
             [TestUtility removeFile:[self.measurement getReportFile]];
-            [TestUtility removeLogAfterAWeek:self.measurement];
         } onError:^(NSError *error) {
             isInExplorer = FALSE;
         }];


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/1212

## Proposed Changes

  - Not calling remove log tied to the report file
  - Creating a new function that returns all measurement with log files
  - Calling this function on app start and removing logs more than 7 days old
