### PR TITLE
Podfile: use ooni/probe-engine 0.16.0 for iOS

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '9.0'
 # ignore all warnings from all pods
 inhibit_all_warnings!
 target 'ooniprobe' do
-    pod 'oonimkall', :podspec => 'https://dl.bintray.com/ooni/ios/oonimkall-2020.07.23-173154.podspec'
+    pod 'oonimkall', :podspec => 'https://dl.bintray.com/ooni/ios/oonimkall-2020.08.21-075809.podspec'
     pod 'mkall', :git => 'https://github.com/measurement-kit/mkall-ios.git', :tag => 'v0.10.0'
     pod 'Toast', '~> 4.0.0'
     pod 'MBProgressHUD'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - mkall (0.10.0)
   - MKDropdownMenu (1.4)
   - OCMapper (2.0)
-  - oonimkall (2020.07.23-173154)
+  - oonimkall (2020.08.21-075809)
   - RHMarkdownLabel (0.0.1):
     - TTTAttributedLabel
     - XNGMarkdownParser
@@ -27,7 +27,7 @@ DEPENDENCIES:
   - mkall (from `https://github.com/measurement-kit/mkall-ios.git`, tag `v0.10.0`)
   - MKDropdownMenu
   - OCMapper (= 2.0)
-  - oonimkall (from `https://dl.bintray.com/ooni/ios/oonimkall-2020.07.23-173154.podspec`)
+  - oonimkall (from `https://dl.bintray.com/ooni/ios/oonimkall-2020.08.21-075809.podspec`)
   - RHMarkdownLabel
   - SharkORM (from `https://github.com/sharksync/sharkorm`, tag `v2.3.67`)
   - Toast (~> 4.0.0)
@@ -51,7 +51,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/measurement-kit/mkall-ios.git
     :tag: v0.10.0
   oonimkall:
-    :podspec: https://dl.bintray.com/ooni/ios/oonimkall-2020.07.23-173154.podspec
+    :podspec: https://dl.bintray.com/ooni/ios/oonimkall-2020.08.21-075809.podspec
   SharkORM:
     :git: https://github.com/sharksync/sharkorm
     :tag: v2.3.67
@@ -73,13 +73,13 @@ SPEC CHECKSUMS:
   mkall: 33f2dddb7e2d87a838d3b0e1403601c0f8d331d4
   MKDropdownMenu: 269df4a41d21a1db684ce8bc709befe419fc5bae
   OCMapper: 9b4d542543794c42adc01f1493d894f53e193cb0
-  oonimkall: b45090d9aa2a25fe4e9434fc6e0a48958fea4d2a
+  oonimkall: 897c3501d020e2038d387e501e020aad01268230
   RHMarkdownLabel: 81d6772768e621be57302b7fd5212ad4f78fb0bd
   SharkORM: 252e4411923110ac1b524a993ee2b3fa13eed7c4
   Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: 9dd55739824a24510dd98085ecd9d47d2a1d9f43
+PODFILE CHECKSUM: d90668d39515addb04d95b9b7776ab2761bf0a91
 
 COCOAPODS: 1.9.3

--- a/ooniprobe/Engine/Engine.m
+++ b/ooniprobe/Engine/Engine.m
@@ -1,7 +1,7 @@
 #import "Engine.h"
 #import <oonimkall/Oonimkall.h>
 #import <mkall/MKVersion.h>
-#define probeEngineTasks @[@"Telegram", @"Ndt", @"Dash", @"Psiphon", @"Tor", @"Whatsapp", @"FacebookMessenger", @"HttpHeaderFieldManipulation", @"HttpInvalidRequestLine"]
+#define probeEngineTasks @[@"Telegram", @"Ndt", @"Dash", @"Psiphon", @"Tor", @"Whatsapp", @"FacebookMessenger", @"HttpHeaderFieldManipulation", @"HttpInvalidRequestLine", @"WebConnectivity"]
 
 @implementation Engine
 


### PR DESCRIPTION
We also switch to using the WebConnectivity provided by probe-engine.

Yet, we're still using MK for some tasks, so we can't pull the plug for now.

Part of https://github.com/ooni/probe-engine/issues/748.

