### PR TITLE
Better interrupt tests

### DIFF
--- a/ooniprobe/Test/Suite/AbstractSuite.m
+++ b/ooniprobe/Test/Suite/AbstractSuite.m
@@ -7,6 +7,7 @@
     if (self) {
         self.backgroundTask = UIBackgroundTaskInvalid;
         self.testList = [[NSMutableArray alloc] init];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(interruptTest) name:@"interruptTest" object:nil];
     }
     return self;
 }
@@ -26,6 +27,7 @@
 }
 
 -(void)runTestSuite {
+    self.interrupted = false;
     [self newResult];
     dispatch_queue_t serialQueue = dispatch_queue_create("org.openobservatory.queue", DISPATCH_QUEUE_SERIAL);
     self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
@@ -47,6 +49,12 @@
         [current runTest];
     }
 }
+
+- (void)interruptTest{
+    NSLog(@"interruptTest AbstractSuite");
+    self.interrupted = true;
+}
+
 
 -(void)testEnded:(AbstractTest*)test{
     [self.testList removeObject:test];

--- a/ooniprobe/Test/Suite/AbstractSuite.m
+++ b/ooniprobe/Test/Suite/AbstractSuite.m
@@ -56,7 +56,6 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"interruptTest" object:nil];
 }
 
-
 -(void)testEnded:(AbstractTest*)test{
     [self.testList removeObject:test];
     [self.result save];

--- a/ooniprobe/Test/Suite/AbstractSuite.m
+++ b/ooniprobe/Test/Suite/AbstractSuite.m
@@ -7,7 +7,6 @@
     if (self) {
         self.backgroundTask = UIBackgroundTaskInvalid;
         self.testList = [[NSMutableArray alloc] init];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(interruptTest) name:@"interruptTest" object:nil];
     }
     return self;
 }
@@ -28,6 +27,7 @@
 
 -(void)runTestSuite {
     self.interrupted = false;
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(interruptTest) name:@"interruptTest" object:nil];
     [self newResult];
     dispatch_queue_t serialQueue = dispatch_queue_create("org.openobservatory.queue", DISPATCH_QUEUE_SERIAL);
     self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
@@ -51,8 +51,9 @@
 }
 
 - (void)interruptTest{
-    NSLog(@"interruptTest AbstractSuite");
+    NSLog(@"interruptTest AbstractSuite %@", self.name);
     self.interrupted = true;
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"interruptTest" object:nil];
 }
 
 

--- a/ooniprobe/Test/Test/AbstractTest.m
+++ b/ooniprobe/Test/Test/AbstractTest.m
@@ -14,6 +14,7 @@
     if (self) {
         self.backgroundTask = UIBackgroundTaskInvalid;
         self.measurements = [[NSMutableDictionary alloc] init];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(interruptTest) name:@"interruptTest" object:nil];
     }
     return self;
 }
@@ -201,9 +202,14 @@
     });
 }
 
+- (void)interruptTest{
+    NSLog(@"interruptTest AbstractTest");
+    if ([self.task canInterrupt])
+        [self.task interrupt];
+}
+
 -(void)testStarted{
     NSMutableDictionary *noteInfo = [[NSMutableDictionary alloc] init];
-    [noteInfo setObject:self.task forKey:@"task"];
     [noteInfo setObject:self.name forKey:@"name"];
     [[NSNotificationCenter defaultCenter] postNotificationName:@"testStarted" object:nil userInfo:noteInfo];
 }

--- a/ooniprobe/Test/Test/AbstractTest.m
+++ b/ooniprobe/Test/Test/AbstractTest.m
@@ -14,7 +14,6 @@
     if (self) {
         self.backgroundTask = UIBackgroundTaskInvalid;
         self.measurements = [[NSMutableDictionary alloc] init];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(interruptTest) name:@"interruptTest" object:nil];
     }
     return self;
 }
@@ -57,6 +56,7 @@
 }
 
 -(void)runTest{
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(interruptTest) name:@"interruptTest" object:nil];
     if(self.annotation)
         [self.settings.annotations setObject:@"ooni-run" forKey:@"origin"];
     self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
@@ -203,9 +203,10 @@
 }
 
 - (void)interruptTest{
-    NSLog(@"interruptTest AbstractTest");
+    NSLog(@"interruptTest AbstractTest %@", self.name);
     if ([self.task canInterrupt])
         [self.task interrupt];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:@"interruptTest" object:nil];
 }
 
 -(void)testStarted{

--- a/ooniprobe/View/RunTest/TestRunningViewController.h
+++ b/ooniprobe/View/RunTest/TestRunningViewController.h
@@ -10,7 +10,6 @@
     LOTAnimationView *animation;
     int totalRuntime;
     AbstractSuite *testSuite;
-    id<OONIMKTask> task;
 }
 
 @property (nonatomic, strong) NSMutableArray *testSuites;

--- a/ooniprobe/View/RunTest/TestRunningViewController.m
+++ b/ooniprobe/View/RunTest/TestRunningViewController.m
@@ -161,8 +161,7 @@
                                handler:^(UIAlertAction * action) {
         [self.runningTestsLabel setText:NSLocalizedString(@"Dashboard.Running.Stopping.Title", nil)];
         [self.logLabel setText:NSLocalizedString(@"Dashboard.Running.Stopping.Notice", nil)];
-        testSuite.interrupted = TRUE;
-        //TODO use notification
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"interruptTest" object:nil];
     }];
     [MessageUtility alertWithTitle:NSLocalizedString(@"Modal.InterruptTest.Title", nil)
                            message:NSLocalizedString(@"Modal.InterruptTest.Paragraph", nil)

--- a/ooniprobe/View/RunTest/TestRunningViewController.m
+++ b/ooniprobe/View/RunTest/TestRunningViewController.m
@@ -95,7 +95,6 @@
 
 -(void)testStarted:(NSNotification *)notification{
     NSDictionary *userInfo = notification.userInfo;
-    task = [userInfo objectForKey:@"task"];
     NSString *name = [userInfo objectForKey:@"name"];
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.testNameLabel setText:[LocalizationUtility getNameForTest:name]];
@@ -163,8 +162,7 @@
         [self.runningTestsLabel setText:NSLocalizedString(@"Dashboard.Running.Stopping.Title", nil)];
         [self.logLabel setText:NSLocalizedString(@"Dashboard.Running.Stopping.Notice", nil)];
         testSuite.interrupted = TRUE;
-        if ([task canInterrupt])
-            [task interrupt];
+        //TODO use notification
     }];
     [MessageUtility alertWithTitle:NSLocalizedString(@"Modal.InterruptTest.Title", nil)
                            message:NSLocalizedString(@"Modal.InterruptTest.Paragraph", nil)


### PR DESCRIPTION
Removing the direct interrupt call on the `task` object and use notification handler that gets destroyed after every test.