### PR TITLE
update riseupvpn test to v. 0.2.0

### DIFF
--- a/ooniprobe/Model/JsonResult/TestKeys.h
+++ b/ooniprobe/Model/JsonResult/TestKeys.h
@@ -54,6 +54,7 @@
 @property (nonatomic, strong) NSString *api_failure;
 @property (nonatomic, strong) NSNumber *ca_cert_status;
 @property (nonatomic, strong) NSArray *failing_gateways;
+@property (nonatomic, strong) NSDictionary *transport_status;
 
 - (NSString*)getJsonStr;
 

--- a/ooniprobe/Test/Test/RiseupVPN.m
+++ b/ooniprobe/Test/Test/RiseupVPN.m
@@ -16,7 +16,9 @@
 }
 
 -(void)onEntry:(JsonResult*)json obj:(Measurement*)measurement{
-    measurement.is_anomaly = !json.test_keys.ca_cert_status.boolValue || json.test_keys.api_failure != nil || json.test_keys.failing_gateways != nil;
+    bool isTransportBlocked = [json.test_keys.transport_status[@"openvpn"]  isEqual: @"blocked"] || [json.test_keys.transport_status[@"obfs4"]  isEqual: @"blocked"];
+
+    measurement.is_anomaly = !json.test_keys.ca_cert_status.boolValue || json.test_keys.api_failure != nil || isTransportBlocked;
     [super onEntry:json obj:measurement];
 
 }


### PR DESCRIPTION
part of https://github.com/ooni/probe/issues/1354

## Proposed Changes

  - same as android: https://github.com/ooni/probe-android/pull/425
  - OONI Probe Android considers a measurement as anomaly if a all gateways supporting a transport are not working (before: if a single gateway fails)
  - the change is implemented with the intention to reduce false positives if one gateway is not working for whatever reason. In reality RiseupVPN users will fallback to other gateways and might be able to connect though those.


I've built the app, and the PR worked, but maybe I missed sth., b/c I didn't dive deep into the codebase.
