### PR TITLE
chore: upgrade to oonimkall v3.11.0-beta.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'ooniprobe' do
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.10.0-beta.3/oonimkall.podspec"
+    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.11.0-beta.2/oonimkall.podspec"
     pod 'Toast', '~> 4.0.0'
     pod 'MBProgressHUD'
     pod 'DZNEmptyDataSet'
@@ -19,7 +19,7 @@ target 'ooniprobe' do
 end
 
 target 'OONIProbeUnitTests' do
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.10.0-beta.3/oonimkall.podspec"
+    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.11.0-beta.2/oonimkall.podspec"
     pod 'SharkORM', :git => 'https://github.com/sharksync/sharkorm', :tag => 'v2.3.67'
     pod 'OCMapper', '2.0'
 end


### PR DESCRIPTION
This (experimental?) diff points to the first version of oonimkall
automatically built using the cloud.

Unfortunately, my local system is quite in a bit of a broken state at
the moment, after the macOS 12.0 system update.

I'm going to use the CI to know whether the automatically built
oonimkall works with the current probe-ios.

Reference issue https://github.com/ooni/probe/issues/1879.