### PR TITLE
Don't start automated-testing if the battery level is less than 20%

### DIFF
--- a/ooniprobe/Notifications/ReachabilityManager.h
+++ b/ooniprobe/Notifications/ReachabilityManager.h
@@ -9,4 +9,5 @@
 - (BOOL)noInternetAccess;
 - (BOOL)isWifi;
 - (BOOL)isVPNConnected;
+- (float)getBatteryLevel;
 @end

--- a/ooniprobe/Notifications/ReachabilityManager.m
+++ b/ooniprobe/Notifications/ReachabilityManager.m
@@ -73,4 +73,13 @@
     return NO;
 }
 
+- (float)getBatteryLevel{
+    [[UIDevice currentDevice] setBatteryMonitoringEnabled:YES];
+    float batteryLevel = [[UIDevice currentDevice] batteryLevel];
+    //This will give you the battery between 0.0 (empty) and 1.0 (100% charged)
+    //If you want it as a percentage, you can do this:
+    batteryLevel *= 100;
+    return batteryLevel;
+}
+
 @end

--- a/ooniprobe/Utility/BackgroundTask.m
+++ b/ooniprobe/Utility/BackgroundTask.m
@@ -65,6 +65,9 @@
     if ([[ReachabilityManager sharedManager] isVPNConnected])
         return;
     
+    if ([[ReachabilityManager sharedManager] getBatteryLevel] < 20)
+        return;
+    
     NSString *testName = @"web_connectivity";
     NSString *testSuiteName = [TestUtility getCategoryForTest:testName];
     AbstractSuite *testSuite = [[AbstractSuite alloc] initSuite:testSuiteName];

--- a/ooniprobe/Utility/BackgroundTask.m
+++ b/ooniprobe/Utility/BackgroundTask.m
@@ -65,7 +65,8 @@
     if ([[ReachabilityManager sharedManager] isVPNConnected])
         return;
     
-    if ([[ReachabilityManager sharedManager] getBatteryLevel] < 20)
+    if ([[ReachabilityManager sharedManager] getBatteryLevel] < 20 &&
+        [[UIDevice currentDevice] batteryState] == UIDeviceBatteryStateUnplugged)
         return;
     
     NSString *testName = @"web_connectivity";


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/1896
