### PR TITLE
fix: only keep arm64 and x86_64 architectures

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,20 @@
+name: archive
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: "0 2 * * */2"
+jobs:
+  archive:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: bundle install
+      - run: pod repo update
+      - run: pod install
+      - run: |
+          set -o pipefail
+          xcodebuild -workspace ooniprobe.xcworkspace -scheme ooniprobe \
+            -destination='name=Any iOS Device' -sdk iphoneos archive | xcpretty
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -15,6 +15,6 @@ jobs:
       - run: |
           set -o pipefail
           xcodebuild -workspace ooniprobe.xcworkspace -scheme ooniprobe \
-            -destination='name=Any iOS Device' -sdk iphoneos archive | xcpretty
+            -destination='name=Any iOS Device' -sdk iphoneos archive CODE_SIGNING_ALLOWED="NO" | xcpretty
         env:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,9 @@ jobs:
       - run: bundle install
       - run: pod repo update
       - run: pod install
-      - run: xcrun simctl list --json devices available
+      - run: xcodebuild -showsdks
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
       - run: |
           set -o pipefail
           xcodebuild clean build test -verbose -workspace ooniprobe.xcworkspace -sdk iphonesimulator \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,6 @@ jobs:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
       - run: |
           set -o pipefail
-          xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator -scheme ooniprobe -destination 'platform=iOS Simulator,name=iPhone 11 Pro Max,OS=15.2'
+          xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator -scheme ooniprobe -destination 'platform=Simulator'
         env:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,9 @@ jobs:
       - run: xcodebuild -showsdks
         env:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+      - run: xcrun simctl list --json devices available
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
       - run: |
           set -o pipefail
           xcodebuild clean build test -verbose -workspace ooniprobe.xcworkspace -sdk iphonesimulator \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - run: pod install
       - run: |
           set -o pipefail
-          xcodebuild clean build test -workspace ooniprobe.xcworkspace/ -sdk iphonesimulator \
-            -scheme ooniprobe -destination 'name=iPhone 11 Pro Max' | xcpretty
+          xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator \
+            -scheme ooniprobe -destination 'name=iPhone 13 mini' | xcpretty
         env:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,14 +12,9 @@ jobs:
       - run: bundle install
       - run: pod repo update
       - run: pod install
-      - run: xcodebuild -showsdks
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
-      - run: xcrun simctl list --json devices available
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
       - run: |
           set -o pipefail
-          xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator -scheme ooniprobe -destination 'platform=iOS Simulator'
+          xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator \
+            -scheme ooniprobe -destination 'name=iPhone 11 Pro Max' | xcpretty
         env:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
       - run: bundle install
       - run: pod repo update
       - run: pod install
+      - run: xcrun simctl list --json devices available
       - run: |
           set -o pipefail
           xcodebuild clean build test -verbose -workspace ooniprobe.xcworkspace -sdk iphonesimulator \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       - run: pod install
       - run: |
           set -o pipefail
-          xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator \
-            -scheme ooniprobe -destination 'name=iPhone 13 mini' | xcpretty
+          xcodebuild clean build test -verbose -workspace ooniprobe.xcworkspace -sdk iphonesimulator \
+            -scheme ooniprobe -destination 'name=iPhone 13 mini'
         env:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,3 +16,5 @@ jobs:
           set -o pipefail
           xcodebuild clean build test -workspace ooniprobe.xcworkspace/ -sdk iphonesimulator \
             -scheme ooniprobe -destination 'name=iPhone 11 Pro Max' | xcpretty
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,9 @@ jobs:
       - run: xcrun simctl list --json devices available
         env:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
+      - run: xcrun instruments -w "*"
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
       - run: |
           set -o pipefail
           xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator -scheme ooniprobe -destination 'platform=Simulator'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,9 +18,6 @@ jobs:
       - run: xcrun simctl list --json devices available
         env:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
-      - run: xcrun instruments -w "*"
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
       - run: |
           set -o pipefail
           xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator -scheme ooniprobe -destination 'platform=iOS Simulator'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,6 @@ jobs:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
       - run: |
           set -o pipefail
-          xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator -scheme ooniprobe -destination 'platform=Simulator'
+          xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator -scheme ooniprobe -destination 'platform=iOS Simulator'
         env:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,6 @@ jobs:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer
       - run: |
           set -o pipefail
-          xcodebuild clean build test -verbose -workspace ooniprobe.xcworkspace -sdk iphonesimulator \
-            -scheme ooniprobe -destination 'name=iPhone 13 mini'
+          xcodebuild clean build test -workspace ooniprobe.xcworkspace -sdk iphonesimulator -scheme ooniprobe -destination 'platform=iOS Simulator,name=iPhone 11 Pro Max,OS=15.2'
         env:
           DEVELOPER_DIR: /Applications/Xcode_13.2.app/Contents/Developer

--- a/ooniprobe.xcodeproj/project.pbxproj
+++ b/ooniprobe.xcodeproj/project.pbxproj
@@ -1647,7 +1647,7 @@
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = ooniprobe;
-				VALID_ARCHS = "armv7s arm64 i386 x86_64";
+				VALID_ARCHS = "arm64 x86_64";
 			};
 			name = Debug;
 		};
@@ -1678,7 +1678,7 @@
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = ooniprobe;
-				VALID_ARCHS = "armv7s arm64";
+				VALID_ARCHS = "arm64";
 			};
 			name = Release;
 		};
@@ -1737,7 +1737,7 @@
 				PROVISIONING_PROFILE = "e7499b75-38e5-4dcb-9cda-ab5aa7ea6eb2";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "arm64 armv7 armv7s i386 x84_64";
+				VALID_ARCHS = "arm64 x84_64";
 			};
 			name = Debug;
 		};
@@ -1791,7 +1791,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "arm64 armv7 armv7s i386 x84_64";
+				VALID_ARCHS = "arm64 x84_64";
 			};
 			name = Release;
 		};
@@ -1800,6 +1800,7 @@
 			baseConfigurationReference = 010F0318C9DE0AC1684DA7D6 /* Pods-ooniprobe.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
+				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1838,7 +1839,7 @@
 				STRIP_INSTALLED_PRODUCT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
-				VALID_ARCHS = "armv7s arm64 i386 x86_64";
+				VALID_ARCHS = "arm64 x86_64";
 			};
 			name = Debug;
 		};
@@ -1847,6 +1848,7 @@
 			baseConfigurationReference = D6B3AA31114A8BF91FF33069 /* Pods-ooniprobe.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
+				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1887,7 +1889,7 @@
 				STRIP_INSTALLED_PRODUCT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
-				VALID_ARCHS = "armv7s arm64";
+				VALID_ARCHS = arm64;
 			};
 			name = Release;
 		};
@@ -1918,7 +1920,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ooniprobe.app/ooniprobe";
-				VALID_ARCHS = "armv7s arm64 i386 x86_64";
+				VALID_ARCHS = "arm64 x86_64";
 			};
 			name = Debug;
 		};
@@ -1949,7 +1951,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ooniprobe.app/ooniprobe";
-				VALID_ARCHS = "armv7s arm64";
+				VALID_ARCHS = "arm64";
 			};
 			name = Release;
 		};

--- a/ooniprobe.xcodeproj/project.pbxproj
+++ b/ooniprobe.xcodeproj/project.pbxproj
@@ -1686,6 +1686,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "arm64 x86_64";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1745,6 +1746,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "arm64 x86_64";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/ooniprobe.xcodeproj/project.pbxproj
+++ b/ooniprobe.xcodeproj/project.pbxproj
@@ -1800,7 +1800,6 @@
 			baseConfigurationReference = 010F0318C9DE0AC1684DA7D6 /* Pods-ooniprobe.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1848,7 +1847,6 @@
 			baseConfigurationReference = D6B3AA31114A8BF91FF33069 /* Pods-ooniprobe.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				ARCHS = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1889,7 +1887,7 @@
 				STRIP_INSTALLED_PRODUCT = NO;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				USER_HEADER_SEARCH_PATHS = "";
-				VALID_ARCHS = arm64;
+				VALID_ARCHS = "arm64";
 			};
 			name = Release;
 		};

--- a/ooniprobe/Info.plist
+++ b/ooniprobe/Info.plist
@@ -69,10 +69,6 @@
 	<string>Main</string>
 	<key>UIMainStoryboardFile~iphone</key>
 	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
 	<key>UIRequiresFullScreen</key>
 	<true/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/project.pbxproj
+++ b/project.pbxproj
@@ -1143,7 +1143,7 @@
 				PROVISIONING_PROFILE = "e7499b75-38e5-4dcb-9cda-ab5aa7ea6eb2";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "arm64 armv7 armv7s i386 x84_64";
+				VALID_ARCHS = "arm64 x84_64";
 			};
 			name = Debug;
 		};
@@ -1192,7 +1192,7 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "arm64 armv7 armv7s i386 x84_64";
+				VALID_ARCHS = "arm64 x84_64";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
See https://github.com/ooni/probe/issues/1918 for a description
of the problem that we want to solve.

See https://github.com/ooni/probe/issues/1918#issuecomment-993383545
instead for the explanation of what's happening.

Closes https://github.com/ooni/probe/issues/1918.

While there, add a new workflow that ensures we're not breaking
the release process in the future without noticing it.