### PR TITLE
Fix: The modal warning about a VPN being enabled is not blocking on the test cards

### DIFF
--- a/ooniprobe/Test/RunningTest.h
+++ b/ooniprobe/Test/RunningTest.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)clearSuites;
 - (void)runTest;
 - (void)networkTestEnded;
-- (void)setAndRun:(NSMutableArray*)testSuites;
+- (void)setAndRun:(NSMutableArray*)testSuites inView:(UIViewController *)view;
 @property (nonatomic, strong) NSMutableArray *testSuites;
 @property (nonatomic, strong) AbstractSuite *testSuite;
 @property (nonatomic, strong) AbstractTest *testRunning;

--- a/ooniprobe/Test/RunningTest.m
+++ b/ooniprobe/Test/RunningTest.m
@@ -1,4 +1,5 @@
 #import "RunningTest.h"
+#import "ReachabilityManager.h"
 
 @implementation RunningTest
 
@@ -26,11 +27,25 @@ static RunningTest *currentTest = nil;
     }
 }
 
--(void)setAndRun:(NSMutableArray*)testSuites {
-    @synchronized(self)
-    {
-        currentTest.testSuites = testSuites;
-        [currentTest runTest];
+- (void)setAndRun:(NSMutableArray *)testSuites inView:(UIViewController *)view {
+    if (view != nil && [[ReachabilityManager sharedManager] isVPNConnected]) {
+        [MessageUtility alertVpnWithTitle:NSLocalizedString(@"Modal.DisableVPN.Title", nil)
+                                  message:NSLocalizedString(@"Modal.DisableVPN.Message", nil)
+                                   inView:view
+                             runVPNAction:^(UIAlertAction *action) {
+                                 @synchronized (self) {
+                                     currentTest.testSuites = testSuites;
+                                     [currentTest runTest];
+                                 }
+                             }
+                         disableVPNAction:nil
+
+        ];
+    } else {
+        @synchronized (self) {
+            currentTest.testSuites = testSuites;
+            [currentTest runTest];
+        }
     }
 }
 

--- a/ooniprobe/Utility/BackgroundTask.m
+++ b/ooniprobe/Utility/BackgroundTask.m
@@ -99,7 +99,7 @@
     CircumventionSuite *cTest = [[CircumventionSuite alloc] init];
     [cTest setStoreDB:NO];
     [tests addObject:cTest];
-    [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithArray:tests]];
+    [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithArray:tests]  inView: nil];
 }
 
 + (void)cancelCheckIn API_AVAILABLE(ios(13.0)){

--- a/ooniprobe/Utility/MessageUtility.h
+++ b/ooniprobe/Utility/MessageUtility.h
@@ -4,6 +4,9 @@
 @interface MessageUtility : NSObject
 
 + (void)showToast:(NSString*)msg inView:(UIView*)view;
+
++ (void)alertVpnWithTitle:(NSString *)title message:(NSString *)msg inView:(UIViewController *)view runVPNAction:(void (^)(UIAlertAction *))runVpnAction disableVPNAction:(void (^)(UIAlertAction *))disableVpnAction;
+
 + (void)alertWithTitle:(NSString *)title message:(NSString *)msg inView:(UIViewController *)view;
 + (void)alertWithTitle:(NSString *)title message:(NSString *)msg okButton:(UIAlertAction*)okButton inView:(UIViewController *)view;
 + (void)alertWithTitle:(NSString *)title message:(NSString *)msg buttons:(NSArray*)buttons inView:(UIViewController *)view;

--- a/ooniprobe/Utility/MessageUtility.m
+++ b/ooniprobe/Utility/MessageUtility.m
@@ -13,6 +13,30 @@
     });
 }
 
++ (void)alertVpnWithTitle:(NSString *)title message:(NSString *)msg
+                   inView:(UIViewController *)view
+             runVPNAction: (void (^ __nullable)(UIAlertAction *action))runVPNAction
+             disableVPNAction: (void (^ __nullable)(UIAlertAction *action))disableVPNAction
+{
+    UIAlertController * alert = [UIAlertController
+            alertControllerWithTitle:title
+                             message:msg
+                      preferredStyle:UIAlertControllerStyleAlert];
+    UIAlertAction* disableVPN = [UIAlertAction
+            actionWithTitle:NSLocalizedString(@"Modal.DisableVPN", nil)
+                      style:UIAlertActionStyleDefault
+                    handler:disableVPNAction];
+    UIAlertAction* runAnyway = [UIAlertAction
+            actionWithTitle:NSLocalizedString(@"Modal.RunAnyway", nil)
+                      style:UIAlertActionStyleDefault
+                    handler:runVPNAction];
+    [alert addAction:runAnyway];
+    [alert addAction:disableVPN];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [view presentViewController:alert animated:YES completion:nil];
+    });
+}
+
 + (void)alertWithTitle:(NSString *)title message:(NSString *)msg inView:(UIViewController *)view
 {
     UIAlertController * alert = [UIAlertController

--- a/ooniprobe/View/DashboardTableViewController.m
+++ b/ooniprobe/View/DashboardTableViewController.m
@@ -137,7 +137,7 @@
         UITableViewCell* cell = (UITableViewCell*)[[[sender superview] superview] superview];
         NSIndexPath* indexPath = [self.tableView indexPathForCell:cell];
         AbstractSuite *testSuite = [items objectAtIndex:indexPath.row];
-        [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite]];
+        [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite] inView: self];
         [self reloadConstraints];
     }
 }
@@ -145,7 +145,7 @@
 -(IBAction)runAll{
     if ([TestUtility checkConnectivity:self] &&
         [TestUtility checkTestRunning:self]){
-        [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithArray:items]];
+        [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithArray:items] inView: self];
         [self reloadConstraints];
     }
 }

--- a/ooniprobe/View/OONIRun/OoniRunViewController.m
+++ b/ooniprobe/View/OONIRun/OoniRunViewController.m
@@ -240,7 +240,7 @@
         [testSuite setTestList:[NSMutableArray arrayWithObject:test]];
         if ([testSuiteName isEqualToString:@"websites"] && [urls count] > 0)
             [(WebConnectivity*)test setInputs:urls];
-        [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite]];
+        [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite] inView:self];
         [vc setPresenting:YES];
     }
 }

--- a/ooniprobe/View/RunTest/TestOverviewViewController.m
+++ b/ooniprobe/View/RunTest/TestOverviewViewController.m
@@ -111,7 +111,7 @@
 -(IBAction)run:(id)sender{
     if ([TestUtility checkConnectivity:self] &&
         [TestUtility checkTestRunning:self]){
-        [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite]];
+        [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite] inView: self];
         [self changeConstraints];
     }
 }

--- a/ooniprobe/View/RunTest/TestRunningViewController.m
+++ b/ooniprobe/View/RunTest/TestRunningViewController.m
@@ -36,9 +36,6 @@
     [[UIApplication sharedApplication] setIdleTimerDisabled:YES];
     if ([RunningTest currentTest].isTestRunning)
         [self testStart];
-    if ([[ReachabilityManager sharedManager] isVPNConnected])
-        [MessageUtility alertWithTitle:NSLocalizedString(@"Modal.DisableVPN.Title", nil)
-                               message:NSLocalizedString(@"Modal.DisableVPN.Message", nil) inView:self];
 }
 
 -(void)viewDidAppear:(BOOL)animated{

--- a/ooniprobe/View/Settings/CustomURLViewController.m
+++ b/ooniprobe/View/Settings/CustomURLViewController.m
@@ -66,7 +66,7 @@
             WebConnectivity *test = [[WebConnectivity alloc] init];
             [testSuite setTestList:[NSMutableArray arrayWithObject:test]];
             [test setInputs:urlArray];
-            [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite]];
+            [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite] inView: self];
             [self.navigationController popToRootViewControllerAnimated:NO];
             self.urlsList = nil;
         }

--- a/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
+++ b/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
@@ -103,7 +103,7 @@
         if ([testSuiteName isEqualToString:@"websites"])
             [(WebConnectivity*)test setInputs:[NSArray arrayWithObject:self.measurement.url_id.url]];
         [self.measurement setReRun];
-        [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite]];
+        [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite] inView:self];
     }
     else if ([[segue identifier] isEqualToString:@"footer_upload"]){
         UploadFooterViewController *vc = (UploadFooterViewController * )segue.destinationViewController;

--- a/ooniprobe/View/TestResults/TestSummaryViewController.m
+++ b/ooniprobe/View/TestResults/TestSummaryViewController.m
@@ -142,7 +142,7 @@
         [urls addObject:m.url_id.url];
     if ([testSuite getTestList] > 0 && [urls count] > 0)
         [(WebConnectivity*)[[testSuite getTestList] objectAtIndex:0] setInputs:urls];
-    [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite]];
+    [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithObject:testSuite] inView: self];
 }
 
 -(void)reRunWebsites{


### PR DESCRIPTION
Fixes ooni/probe#1982

## Proposed Changes

  - Check If VPN is enabled before launching service and prompt user to change VPN settings before proceeding.

| .| . | . |
| ------------- | ------------- | ------------- |
| ![IMG_3A4CC74D8174-1](https://user-images.githubusercontent.com/17911892/157609257-4bc358e4-e91d-4065-9432-06fa92c731f7.jpeg) | ![IMG_931570BACB7D-1](https://user-images.githubusercontent.com/17911892/157609313-4cb1590c-3340-4680-9272-b6e81c4c5e63.jpeg) | ![IMG_2447E71C99C5-1](https://user-images.githubusercontent.com/17911892/157609339-57e34e93-bc7c-4bc2-b108-1e5b11187229.jpeg) |

