### PR TITLE
Modified  to trigger test started before downloading  to fix test start delay

### DIFF
--- a/ooniprobe/Test/Test/AbstractTest.h
+++ b/ooniprobe/Test/Test/AbstractTest.h
@@ -36,5 +36,6 @@
 -(void)prepareRun;
 -(void)runTest;
 -(int)getRuntime;
+-(void)testStarted;
 -(void)testEnded;
 @end

--- a/ooniprobe/Test/Test/WebConnectivity.m
+++ b/ooniprobe/Test/Test/WebConnectivity.m
@@ -19,6 +19,7 @@
     [super prepareRun];
     dispatch_async(self.serialQueue, ^{
         if (self.inputs == nil || [self.inputs count] == 0){
+            [super testStarted];
             //Download urls and then alloc class
             [OONIApi downloadUrls:^(NSArray *urls) {
                 [self setUrls:urls];


### PR DESCRIPTION
Work around for  https://github.com/ooni/probe/issues/2054 

## Proposed Changes

  - Triggers `AbstractTest.testStarted` to update UI similar to what happens in android  [`TestAsyncTask.doInBackground`](https://github.com/ooni/probe-android/blob/master/app/src/main/java/org/openobservatory/ooniprobe/test/TestAsyncTask.java#L127).

> Further investigations around https://github.com/ooni/probe/issues/2054  showed the  process is stuck while the URLs are being downloaded