### PR TITLE
Add possibility to cancel the upload of the measurement

### DIFF
--- a/ooniprobe/View/TestResults/Footer/UploadFooterViewController.h
+++ b/ooniprobe/View/TestResults/Footer/UploadFooterViewController.h
@@ -21,4 +21,7 @@
 @property (nonatomic, strong) LoggerArray* logger;
 
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundTask;
+
+@property (atomic, assign) BOOL canceled;
+
 @end

--- a/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
+++ b/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
@@ -69,6 +69,10 @@
     }
 }
 
+- (void)cancelUpload:(id)sender {
+    self.canceled = YES;
+}
+
 //SRKResultSet is a subclass of NSArray
 -(void)uploadMeasurements:(NSArray *)notUploaded{
     self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
@@ -81,6 +85,10 @@
             hud.mode = MBProgressHUDModeAnnularDeterminate;
             hud.bezelView.color = [UIColor lightGrayColor];
             hud.backgroundView.style = UIBlurEffectStyleRegular;
+
+            [hud.button setTitle:NSLocalizedFormatString(@"Modal.Cancel",nil) forState:UIControlStateNormal];
+            [hud.button addTarget:self action:@selector(cancelUpload:) forControlEvents:UIControlEventTouchUpInside];
+
         });
         NSUInteger errors = 0;
         if ([notUploaded count] == 0) return;
@@ -105,6 +113,9 @@
             return;
         }
         while (i < [notUploaded count]){
+            if (_canceled){
+                break;
+            }
             Measurement *currentMeasurement = [notUploaded objectAtIndex:i];
             dispatch_async(dispatch_get_main_queue(), ^{
                 [MBProgressHUD HUDForView:self.navigationController.view].label.text =
@@ -120,6 +131,7 @@
                 [MBProgressHUD HUDForView:self.navigationController.view].progress = progress;
             });
         }
+        _canceled = NO;
         dispatch_async(dispatch_get_main_queue(), ^{
             [MBProgressHUD hideHUDForView:self.navigationController.view animated:YES];
         });


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/1252

## Proposed Changes
- Add `Cancel` button to the progress modal.

|.|.|.|.|
|--|--|--|--|
| ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-04-05 at 07 49 27](https://user-images.githubusercontent.com/17911892/161695564-f09053e8-fa79-44cf-bff9-bf0bb1ebafb0.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-04-05 at 07 49 14](https://user-images.githubusercontent.com/17911892/161695591-9d08a89f-bbf9-4bd9-a12c-587191055fca.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-04-05 at 07 42 20](https://user-images.githubusercontent.com/17911892/161695598-1ebbbe3f-8f22-4691-a65e-b0a5126177ee.png) | ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-04-05 at 07 42 03](https://user-images.githubusercontent.com/17911892/161695606-9473049a-6387-4f20-bc84-1441719757a1.png) |
