### PR TITLE
Improve communication of which websites are tested by OONI Probe

### DIFF
--- a/ooniprobe/Base.lproj/Localizable.strings
+++ b/ooniprobe/Base.lproj/Localizable.strings
@@ -407,6 +407,7 @@
 "Settings.Websites.CustomURL.NoURLEntered" = "No URLs entered";
 "Settings.Websites.CustomURL.Run" = "Run";
 "Settings.Websites.CustomURL.Add" = "Add website";
+"Settings.Websites.CustomURL.LoadFromTemplate" = "Load from template";
 "Settings.Websites.TestCount" = "Number of tested websites (0 means all)";
 "Settings.InstantMessaging.TestWhatsApp" = "Test WhatsApp";
 "Settings.InstantMessaging.TestTelegram" = "Test Telegram";

--- a/ooniprobe/Storyboards/Settings.storyboard
+++ b/ooniprobe/Storyboards/Settings.storyboard
@@ -251,12 +251,27 @@
                                                 <constraint firstAttribute="height" constant="38" id="xLg-tO-USr"/>
                                             </constraints>
                                         </view>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kp4-fW-j6p" customClass="RunButton">
-                                            <rect key="frame" x="143.5" y="52" width="88" height="44"/>
+                                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nho-Gx-2qi" customClass="RunButton">
+                                            <rect key="frame" x="152" y="52" width="193" height="44"/>
+                                            <color key="backgroundColor" name="color_base"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="44" id="Akt-Mb-EW9"/>
+                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="xqm-PA-uL4"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" name="FiraSans-Regular" family="Fira Sans" pointSize="21"/>
+                                            <state key="normal" title="Load from template">
+                                                <color key="titleColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.94901960780000005" alpha="1" colorSpace="calibratedRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="loadFromTemplate:" destination="NsA-cf-UBX" eventType="touchUpInside" id="eEg-za-Vtz"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kp4-fW-j6p" customClass="RunButton">
+                                            <rect key="frame" x="30" y="52" width="70" height="44"/>
                                             <color key="backgroundColor" name="color_base"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="44" id="177-gP-bRa"/>
-                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="88" id="UIy-sn-ExB"/>
+                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="UIy-sn-ExB"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" name="FiraSans-Regular" family="Fira Sans" pointSize="21"/>
                                             <state key="normal" title="Run">
@@ -269,10 +284,13 @@
                                     </subviews>
                                     <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                     <constraints>
+                                        <constraint firstAttribute="trailing" secondItem="nho-Gx-2qi" secondAttribute="trailing" constant="30" id="B9N-Ul-wwD"/>
                                         <constraint firstAttribute="bottom" secondItem="Kp4-fW-j6p" secondAttribute="bottom" id="Eke-OL-Ryt"/>
+                                        <constraint firstItem="nho-Gx-2qi" firstAttribute="top" secondItem="bu7-Z3-ub0" secondAttribute="bottom" constant="14" id="Rvp-uy-VCT"/>
                                         <constraint firstItem="bu7-Z3-ub0" firstAttribute="leading" secondItem="mU1-HQ-BWg" secondAttribute="leading" id="Th0-l6-xMz"/>
+                                        <constraint firstItem="Kp4-fW-j6p" firstAttribute="leading" secondItem="mU1-HQ-BWg" secondAttribute="leading" constant="30" id="WXa-Kv-sll"/>
+                                        <constraint firstItem="nho-Gx-2qi" firstAttribute="leading" secondItem="Kp4-fW-j6p" secondAttribute="trailing" constant="34" id="d7y-FW-d8X"/>
                                         <constraint firstItem="bu7-Z3-ub0" firstAttribute="top" secondItem="mU1-HQ-BWg" secondAttribute="top" id="kfa-2e-GAI"/>
-                                        <constraint firstItem="Kp4-fW-j6p" firstAttribute="centerX" secondItem="mU1-HQ-BWg" secondAttribute="centerX" id="mr6-1M-n5L"/>
                                         <constraint firstAttribute="trailing" secondItem="bu7-Z3-ub0" secondAttribute="trailing" id="vHY-We-fvN"/>
                                     </constraints>
                                 </view>
@@ -337,6 +355,7 @@
                     </view>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
+                        <outlet property="loadFromTemplateButton" destination="nho-Gx-2qi" id="K38-Uy-Sab"/>
                         <outlet property="runButton" destination="Kp4-fW-j6p" id="v58-6G-flD"/>
                         <outlet property="tableView" destination="NqN-lv-rjI" id="xlq-cm-5U0"/>
                         <segue destination="fha-Tp-5xt" kind="presentation" identifier="toTestRun" id="ypz-OB-EIM"/>

--- a/ooniprobe/View/Settings/CustomURLViewController.h
+++ b/ooniprobe/View/Settings/CustomURLViewController.h
@@ -11,5 +11,6 @@
 @property (strong, nonatomic) NSMutableArray *urlsList;
 @property (nonatomic, retain) IBOutlet UITableView *tableView;
 @property (nonatomic, retain) IBOutlet RunButton *runButton;
+@property (strong, nonatomic) IBOutlet RunButton *loadFromTemplateButton;
 
 @end


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/1929 , https://github.com/ooni/probe/issues/1935

## Proposed Changes

  - Add button to load websites (`loadFromTemplateButton`) used in `web_connectivity` test in `CustomURLViewController`.
  - Fetch and display websites in webconnectivity when `loadFromTemplateButton` is clicked, making `loadFromTemplateButton` invisible when successful.

| . | . | . |
| -- | -- | -- |
|  ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-04-06 at 21 27 44](https://user-images.githubusercontent.com/17911892/162071821-31c83fd6-bb4b-4f5e-b735-f467da0213b0.png) |![Simulator Screen Shot - iPhone 13 Pro Max - 2022-04-06 at 21 27 47](https://user-images.githubusercontent.com/17911892/162071818-1086a570-cf75-499d-9209-c2755b301327.png) |  ![Simulator Screen Shot - iPhone 13 Pro Max - 2022-04-06 at 22 12 23](https://user-images.githubusercontent.com/17911892/162071800-0fba36d5-4cea-4156-81a9-4d5c02e3aea6.png) | 

