### PR TITLE
chore: use ooni/probe-cli v3.15.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'ooniprobe' do
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.0/oonimkall.podspec"
+    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.1/oonimkall.podspec"
     pod 'Toast', '~> 4.0.0'
     pod 'MBProgressHUD'
     pod 'DZNEmptyDataSet'
@@ -19,7 +19,7 @@ target 'ooniprobe' do
 end
 
 target 'OONIProbeUnitTests' do
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.0/oonimkall.podspec"
+    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.1/oonimkall.podspec"
     pod 'SharkORM', :git => 'https://github.com/sharksync/sharkorm', :tag => 'v2.3.67'
     pod 'OCMapper', '2.0'
 end

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'ooniprobe' do
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.0-alpha.1/oonimkall.podspec"
+    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.0/oonimkall.podspec"
     pod 'Toast', '~> 4.0.0'
     pod 'MBProgressHUD'
     pod 'DZNEmptyDataSet'
@@ -19,7 +19,7 @@ target 'ooniprobe' do
 end
 
 target 'OONIProbeUnitTests' do
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.0-alpha.1/oonimkall.podspec"
+    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.0/oonimkall.podspec"
     pod 'SharkORM', :git => 'https://github.com/sharksync/sharkorm', :tag => 'v2.3.67'
     pod 'OCMapper', '2.0'
 end

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'ooniprobe' do
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.14.1/oonimkall.podspec"
+    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.0-alpha.1/oonimkall.podspec"
     pod 'Toast', '~> 4.0.0'
     pod 'MBProgressHUD'
     pod 'DZNEmptyDataSet'
@@ -19,7 +19,7 @@ target 'ooniprobe' do
 end
 
 target 'OONIProbeUnitTests' do
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.14.1/oonimkall.podspec"
+    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.0-alpha.1/oonimkall.podspec"
     pod 'SharkORM', :git => 'https://github.com/sharksync/sharkorm', :tag => 'v2.3.67'
     pod 'OCMapper', '2.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - MBProgressHUD (1.2.0)
   - MKDropdownMenu (1.4)
   - OCMapper (2.0)
-  - oonimkall (2022.05.23-164652)
+  - oonimkall (2022.06.02-094639)
   - RHMarkdownLabel (0.0.1):
     - TTTAttributedLabel
     - XNGMarkdownParser
@@ -30,7 +30,7 @@ DEPENDENCIES:
   - MBProgressHUD
   - MKDropdownMenu
   - OCMapper (= 2.0)
-  - oonimkall (from `https://github.com/ooni/probe-cli/releases/download/v3.15.0-alpha.1/oonimkall.podspec`)
+  - oonimkall (from `https://github.com/ooni/probe-cli/releases/download/v3.15.0/oonimkall.podspec`)
   - RHMarkdownLabel
   - Sentry (from `https://github.com/getsentry/sentry-cocoa.git`, tag `6.1.4`)
   - SharkORM (from `https://github.com/sharksync/sharkorm`, tag `v2.3.67`)
@@ -53,7 +53,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   oonimkall:
-    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.15.0-alpha.1/oonimkall.podspec
+    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.15.0/oonimkall.podspec
   Sentry:
     :git: https://github.com/getsentry/sentry-cocoa.git
     :tag: 6.1.4
@@ -78,7 +78,7 @@ SPEC CHECKSUMS:
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   MKDropdownMenu: 269df4a41d21a1db684ce8bc709befe419fc5bae
   OCMapper: 9b4d542543794c42adc01f1493d894f53e193cb0
-  oonimkall: bee1c63da86af16810b31fbc0581de821574a100
+  oonimkall: 5aa74dd454bf50c5c6c5e91ef5d86b7f27197907
   RHMarkdownLabel: 81d6772768e621be57302b7fd5212ad4f78fb0bd
   Sentry: 9d055e2de30a77685e86b219acf02e59b82091fc
   SharkORM: 252e4411923110ac1b524a993ee2b3fa13eed7c4
@@ -86,6 +86,6 @@ SPEC CHECKSUMS:
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: fe8566bf6f67e0c5ae07afd4e28b5472bb1e18f0
+PODFILE CHECKSUM: 2291167ab6762aead1ca70274170ce1c72cc0f84
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - MBProgressHUD (1.2.0)
   - MKDropdownMenu (1.4)
   - OCMapper (2.0)
-  - oonimkall (2022.06.02-094639)
+  - oonimkall (2022.06.07-100904)
   - RHMarkdownLabel (0.0.1):
     - TTTAttributedLabel
     - XNGMarkdownParser
@@ -30,7 +30,7 @@ DEPENDENCIES:
   - MBProgressHUD
   - MKDropdownMenu
   - OCMapper (= 2.0)
-  - oonimkall (from `https://github.com/ooni/probe-cli/releases/download/v3.15.0/oonimkall.podspec`)
+  - oonimkall (from `https://github.com/ooni/probe-cli/releases/download/v3.15.1/oonimkall.podspec`)
   - RHMarkdownLabel
   - Sentry (from `https://github.com/getsentry/sentry-cocoa.git`, tag `6.1.4`)
   - SharkORM (from `https://github.com/sharksync/sharkorm`, tag `v2.3.67`)
@@ -53,7 +53,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   oonimkall:
-    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.15.0/oonimkall.podspec
+    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.15.1/oonimkall.podspec
   Sentry:
     :git: https://github.com/getsentry/sentry-cocoa.git
     :tag: 6.1.4
@@ -78,7 +78,7 @@ SPEC CHECKSUMS:
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   MKDropdownMenu: 269df4a41d21a1db684ce8bc709befe419fc5bae
   OCMapper: 9b4d542543794c42adc01f1493d894f53e193cb0
-  oonimkall: 5aa74dd454bf50c5c6c5e91ef5d86b7f27197907
+  oonimkall: 07f9815f6ef15b087bf64f041b8dfc1e7a4f7d27
   RHMarkdownLabel: 81d6772768e621be57302b7fd5212ad4f78fb0bd
   Sentry: 9d055e2de30a77685e86b219acf02e59b82091fc
   SharkORM: 252e4411923110ac1b524a993ee2b3fa13eed7c4
@@ -86,6 +86,6 @@ SPEC CHECKSUMS:
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: 2291167ab6762aead1ca70274170ce1c72cc0f84
+PODFILE CHECKSUM: 68dc56c1b0a05d1a352c13479e80fd1eb9ec15c4
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - MBProgressHUD (1.2.0)
   - MKDropdownMenu (1.4)
   - OCMapper (2.0)
-  - oonimkall (2022.02.23-152349)
+  - oonimkall (2022.05.23-164652)
   - RHMarkdownLabel (0.0.1):
     - TTTAttributedLabel
     - XNGMarkdownParser
@@ -30,7 +30,7 @@ DEPENDENCIES:
   - MBProgressHUD
   - MKDropdownMenu
   - OCMapper (= 2.0)
-  - oonimkall (from `https://github.com/ooni/probe-cli/releases/download/v3.14.1/oonimkall.podspec`)
+  - oonimkall (from `https://github.com/ooni/probe-cli/releases/download/v3.15.0-alpha.1/oonimkall.podspec`)
   - RHMarkdownLabel
   - Sentry (from `https://github.com/getsentry/sentry-cocoa.git`, tag `6.1.4`)
   - SharkORM (from `https://github.com/sharksync/sharkorm`, tag `v2.3.67`)
@@ -53,7 +53,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   oonimkall:
-    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.14.1/oonimkall.podspec
+    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.15.0-alpha.1/oonimkall.podspec
   Sentry:
     :git: https://github.com/getsentry/sentry-cocoa.git
     :tag: 6.1.4
@@ -78,7 +78,7 @@ SPEC CHECKSUMS:
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   MKDropdownMenu: 269df4a41d21a1db684ce8bc709befe419fc5bae
   OCMapper: 9b4d542543794c42adc01f1493d894f53e193cb0
-  oonimkall: 1de2d8616af8a3904e03988e426fdab96d85a1e1
+  oonimkall: bee1c63da86af16810b31fbc0581de821574a100
   RHMarkdownLabel: 81d6772768e621be57302b7fd5212ad4f78fb0bd
   Sentry: 9d055e2de30a77685e86b219acf02e59b82091fc
   SharkORM: 252e4411923110ac1b524a993ee2b3fa13eed7c4
@@ -86,6 +86,6 @@ SPEC CHECKSUMS:
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: a75c0f0061e73038b75b6b5f62c4873a60927ec4
+PODFILE CHECKSUM: fe8566bf6f67e0c5ae07afd4e28b5472bb1e18f0
 
 COCOAPODS: 1.11.3

--- a/ooniprobe/Test/Suite/AbstractSuite.h
+++ b/ooniprobe/Test/Suite/AbstractSuite.h
@@ -15,6 +15,7 @@
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundTask;
 @property BOOL interrupted;
 @property BOOL storeDB;
+@property BOOL autoRUn;
 @property float totalTests;
 
 -(id)initSuite:(NSString*)testSuite;

--- a/ooniprobe/Test/Suite/ExperimentalSuite.m
+++ b/ooniprobe/Test/Suite/ExperimentalSuite.m
@@ -16,6 +16,7 @@
         [self.testList addObject:[[Experimental alloc] initWithName:@"stunreachability"]];
         [self.testList addObject:[[Experimental alloc] initWithName:@"dnscheck"]];
         [self.testList addObject:[[Experimental alloc] initWithName:@"torsf"]];
+        [self.testList addObject:[[Experimental alloc] initWithName:@"vanilla_tor"]];
     }
     return super.getTestList;
 }

--- a/ooniprobe/Test/Suite/ExperimentalSuite.m
+++ b/ooniprobe/Test/Suite/ExperimentalSuite.m
@@ -11,12 +11,14 @@
     return self;
 }
 
-- (NSArray*)getTestList {
-    if ([self.testList count] == 0){
+- (NSArray *)getTestList {
+    if ([self.testList count] == 0) {
+        if (self.autoRUn) {
+            [self.testList addObject:[[Experimental alloc] initWithName:@"torsf"]];
+            [self.testList addObject:[[Experimental alloc] initWithName:@"vanilla_tor"]];
+        }
         [self.testList addObject:[[Experimental alloc] initWithName:@"stunreachability"]];
         [self.testList addObject:[[Experimental alloc] initWithName:@"dnscheck"]];
-        [self.testList addObject:[[Experimental alloc] initWithName:@"torsf"]];
-        [self.testList addObject:[[Experimental alloc] initWithName:@"vanilla_tor"]];
     }
     return super.getTestList;
 }

--- a/ooniprobe/Utility/BackgroundTask.m
+++ b/ooniprobe/Utility/BackgroundTask.m
@@ -99,6 +99,10 @@
     CircumventionSuite *cTest = [[CircumventionSuite alloc] init];
     [cTest setStoreDB:NO];
     [tests addObject:cTest];
+    ExperimentalSuite *eTest = [[ExperimentalSuite alloc] init];
+    [eTest setStoreDB:NO];
+    [eTest setAutoRUn:YES];
+    [tests addObject:eTest];
     [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithArray:tests]  inView: nil];
 }
 

--- a/ooniprobe/Utility/LocalizationUtility.m
+++ b/ooniprobe/Utility/LocalizationUtility.m
@@ -60,7 +60,8 @@
         return NSLocalizedFormatString(@"Dashboard.Experimental.Overview.Paragraph",
                                        @"\n\n- [STUN Reachability](https://github.com/ooni/spec/blob/master/nettests/ts-025-stun-reachability.md) "
                                         "\n\n- [DNS Check](https://github.com/ooni/spec/blob/master/nettests/ts-028-dnscheck.md) "
-                                        "\n\n- [Tor Snowflake](https://ooni.org/nettest/tor-snowflake/) ");
+                                        "\n\n- [Tor Snowflake](https://ooni.org/nettest/tor-snowflake/) "
+                                        "\n\n- [Vanilla Tor](https://github.com/ooni/spec/blob/master/nettests/ts-016-vanilla-tor.md) ");
     return @"";
 }
 


### PR DESCRIPTION
This pull request upgrades to ooni/probe-cli v3.15.x1

See https://github.com/ooni/probe/issues/2100