### PR TITLE
Wrong ASN displayed in successful results of a re-run failed test when different network is selected.

### DIFF
--- a/ooniprobe/Model/Database/Measurement.h
+++ b/ooniprobe/Model/Database/Measurement.h
@@ -19,6 +19,7 @@
 @property BOOL is_upload_failed;
 @property NSString *upload_failure_msg;
 @property BOOL is_rerun;
+@property NSDictionary* rerun_network;
 @property NSString *report_id;
 @property Url *url_id;
 @property BOOL is_anomaly;

--- a/ooniprobe/Model/Database/Measurement.m
+++ b/ooniprobe/Model/Database/Measurement.m
@@ -5,7 +5,7 @@
 #import "OONIApi.h"
 
 @implementation Measurement
-@dynamic test_name, start_time, runtime, is_done, is_uploaded, is_failed, failure_msg, is_upload_failed, upload_failure_msg, is_rerun, report_id, url_id, test_keys, is_anomaly, result_id;
+@dynamic test_name, start_time, runtime, is_done, is_uploaded, is_failed, failure_msg, is_upload_failed, upload_failure_msg, is_rerun, rerun_network, report_id, url_id, test_keys, is_anomaly, result_id;
 
 @synthesize testKeysObj = _testKeysObj;
 

--- a/ooniprobe/Test/Test/AbstractTest.h
+++ b/ooniprobe/Test/Test/AbstractTest.h
@@ -24,7 +24,9 @@
 @property (nonatomic, strong) NSMutableDictionary *measurements;
 @property id<MKNetworkTestDelegate> delegate;
 @property Settings *settings;
+@property NSDictionary *network;
 @property BOOL annotation;
+@property BOOL is_rerun;
 @property dispatch_queue_t serialQueue;
 @property id<OONIMKTask> task;
 @property BOOL storeDB;

--- a/ooniprobe/Test/Test/AbstractTest.m
+++ b/ooniprobe/Test/Test/AbstractTest.m
@@ -112,6 +112,16 @@
                 }
             }
             else if ([event.key isEqualToString:@"status.geoip_lookup"]) {
+                self.network=nil;
+                if (self.is_rerun){
+                    self.network = @{
+                            @"network_name":event.value.probe_network_name,
+                            @"asn":event.value.probe_asn,
+                            @"ip" :event.value.probe_ip,
+                            @"country_code":  event.value.probe_cc,
+                            @"network_type": [[ReachabilityManager sharedManager] getStatus],
+                    };
+                }
                 //Save Network info
                 [self saveNetworkInfo:event.value];
             }
@@ -287,6 +297,9 @@
         }
         [TestUtility writeString:str toFile:[TestUtility getFileNamed:[measurement getReportFile]]];
         [self onEntry:[TestUtility jsonResultfromDic:jsonDic] obj:measurement];
+        if (self.network!=nil){
+            measurement.rerun_network = self.network;
+        }
         [measurement save];
         [self.result save];
     }

--- a/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
+++ b/ooniprobe/View/TestResults/Details/TestDetailsViewController.m
@@ -98,6 +98,7 @@
         NSString *testSuiteName = self.measurement.result_id.test_group_name;
         AbstractSuite *testSuite = [[AbstractSuite alloc] initSuite:testSuiteName];
         AbstractTest *test = [[AbstractTest alloc] initTest:self.measurement.test_name];
+        test.is_rerun = true;
         [testSuite setTestList:[NSMutableArray arrayWithObject:test]];
         [testSuite setResult:self.measurement.result_id];
         if ([testSuiteName isEqualToString:@"websites"])

--- a/ooniprobe/View/TestResults/Footer/TestDetailsFooterViewController.m
+++ b/ooniprobe/View/TestResults/Footer/TestDetailsFooterViewController.m
@@ -29,9 +29,12 @@
     [self.runtimeLabel setText:NSLocalizedString(@"TestResults.Details.Hero.Runtime", nil)];
     [self.dateLabel setText:NSLocalizedString(@"TestResults.Summary.Hero.DateAndTime", nil)];
     [self.dateDetailLabel setText:[measurement getLocalizedStartTime]];
-    [self.networkNameLabel setText:[result getNetworkName]];
-    [self.networkAsnLabel setText:[NSString stringWithFormat:@"%@ (%@)", [result getAsn], [result getLocalizedNetworkType]]];
-    NSString *country = [result getCountry];
+    NSString *country = measurement.rerun_network[@"country_code"] ?: [result getCountry];
+    NSString *networkName = measurement.rerun_network[@"network_name"] ?: [result getNetworkName];
+    NSString *asn =measurement.rerun_network[@"asn"] ?: [result getAsn];
+    NSString *networkType = measurement.rerun_network[@"network_type"] ?: [result getLocalizedNetworkType];
+    [self.networkNameLabel setText:networkName];
+    [self.networkAsnLabel setText:[NSString stringWithFormat:@"%@ (%@)", asn, networkType]];
     [self.countryDetailLabel setText:country];
     
     [self.runtimeDetailLabel setText:[NSString stringWithFormat:@"%.02f sec", measurement.runtime]];


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/851

## Proposed Changes

  -  Update `Measurement`  table to add  `rerun_network` column.
  - Annotate  `AbstractTest` before rerun is triggered.
  - Capture network during `status.geoip_lookup` event and save to class instance.
  - Update measurement to include new network during `measurement` probe-enigine evennt