### PR TITLE
Feat: append `-unattended` to software_name used for unattended runs

### DIFF
--- a/ooniprobe/Test/Suite/AbstractSuite.h
+++ b/ooniprobe/Test/Suite/AbstractSuite.h
@@ -15,7 +15,7 @@
 @property (nonatomic) UIBackgroundTaskIdentifier backgroundTask;
 @property BOOL interrupted;
 @property BOOL storeDB;
-@property BOOL autoRUn;
+@property BOOL autoRun;
 @property float totalTests;
 
 -(id)initSuite:(NSString*)testSuite;

--- a/ooniprobe/Test/Suite/AbstractSuite.m
+++ b/ooniprobe/Test/Suite/AbstractSuite.m
@@ -100,7 +100,7 @@
 }
 
 -(NSArray*)getTestList {
-    if (self.autoRun){
+    if (self.autoRun) {
         for (int i = 0; i < [self.testList count]; ++i) {
             AbstractTest *current = self.testList[(NSUInteger) i];
             current.autoRun = YES;

--- a/ooniprobe/Test/Suite/AbstractSuite.m
+++ b/ooniprobe/Test/Suite/AbstractSuite.m
@@ -100,6 +100,13 @@
 }
 
 -(NSArray*)getTestList {
+    if (self.autoRUn){
+        for (int i = 0; i < [self.testList count]; ++i) {
+            AbstractTest *current = self.testList[(NSUInteger) i];
+            current.autoRUn = YES;
+            self.testList[(NSUInteger) i] = current;
+        }
+    }
     return self.testList;
 }
 

--- a/ooniprobe/Test/Suite/AbstractSuite.m
+++ b/ooniprobe/Test/Suite/AbstractSuite.m
@@ -100,9 +100,11 @@
 }
 
 -(NSArray*)getTestList {
-    if (self.autoRUn){
+    if (self.autoRun){
         for (int i = 0; i < [self.testList count]; ++i) {
-            self.testList[(NSUInteger) i].autoRUn = YES;
+            AbstractTest *current = self.testList[(NSUInteger) i];
+            current.autoRun = YES;
+            self.testList[(NSUInteger) i] = current;
         }
     }
     return self.testList;

--- a/ooniprobe/Test/Suite/AbstractSuite.m
+++ b/ooniprobe/Test/Suite/AbstractSuite.m
@@ -102,9 +102,7 @@
 -(NSArray*)getTestList {
     if (self.autoRUn){
         for (int i = 0; i < [self.testList count]; ++i) {
-            AbstractTest *current = self.testList[(NSUInteger) i];
-            current.autoRUn = YES;
-            self.testList[(NSUInteger) i] = current;
+            self.testList[(NSUInteger) i].autoRUn = YES;
         }
     }
     return self.testList;

--- a/ooniprobe/Test/Suite/ExperimentalSuite.m
+++ b/ooniprobe/Test/Suite/ExperimentalSuite.m
@@ -13,7 +13,7 @@
 
 - (NSArray *)getTestList {
     if ([self.testList count] == 0) {
-        if (self.autoRUn) {
+        if (self.autoRun) {
             [self.testList addObject:[[Experimental alloc] initWithName:@"torsf"]];
             [self.testList addObject:[[Experimental alloc] initWithName:@"vanilla_tor"]];
         }

--- a/ooniprobe/Test/Test/AbstractTest.h
+++ b/ooniprobe/Test/Test/AbstractTest.h
@@ -30,7 +30,7 @@
 @property dispatch_queue_t serialQueue;
 @property id<OONIMKTask> task;
 @property BOOL storeDB;
-@property BOOL autoRUn;
+@property BOOL autoRun;
 @property BOOL isPreparing;
 
 -(id)initTest:(NSString*)testName;

--- a/ooniprobe/Test/Test/AbstractTest.h
+++ b/ooniprobe/Test/Test/AbstractTest.h
@@ -30,6 +30,7 @@
 @property dispatch_queue_t serialQueue;
 @property id<OONIMKTask> task;
 @property BOOL storeDB;
+@property BOOL autoRUn;
 @property BOOL isPreparing;
 
 -(id)initTest:(NSString*)testName;

--- a/ooniprobe/Test/Test/AbstractTest.m
+++ b/ooniprobe/Test/Test/AbstractTest.m
@@ -57,7 +57,7 @@
 
 -(void)prepareRun{
     self.settings = [Settings new];
-    if (self.autoRUn){
+    if (self.autoRUn) {
         self.settings.annotations[@"origin"] = @"autorun";
         self.settings.options.software_name = [NSString stringWithFormat:@"%@%@",SOFTWARE_NAME,@"-unattended"];
         NSLog(self.settings.annotations[@"origin"]);

--- a/ooniprobe/Test/Test/AbstractTest.m
+++ b/ooniprobe/Test/Test/AbstractTest.m
@@ -57,7 +57,7 @@
 
 -(void)prepareRun{
     self.settings = [Settings new];
-    if (self.autoRUn) {
+    if (self.autoRun) {
         self.settings.annotations[@"origin"] = @"autorun";
         self.settings.options.software_name = [NSString stringWithFormat:@"%@%@",SOFTWARE_NAME,@"-unattended"];
     }

--- a/ooniprobe/Test/Test/AbstractTest.m
+++ b/ooniprobe/Test/Test/AbstractTest.m
@@ -60,7 +60,6 @@
     if (self.autoRUn) {
         self.settings.annotations[@"origin"] = @"autorun";
         self.settings.options.software_name = [NSString stringWithFormat:@"%@%@",SOFTWARE_NAME,@"-unattended"];
-        NSLog(self.settings.annotations[@"origin"]);
     }
     self.settings.name = self.name;
 }

--- a/ooniprobe/Test/Test/AbstractTest.m
+++ b/ooniprobe/Test/Test/AbstractTest.m
@@ -57,6 +57,11 @@
 
 -(void)prepareRun{
     self.settings = [Settings new];
+    if (self.autoRUn){
+        self.settings.annotations[@"origin"] = @"autorun";
+        self.settings.options.software_name = [NSString stringWithFormat:@"%@%@",SOFTWARE_NAME,@"-unattended"];
+        NSLog(self.settings.annotations[@"origin"]);
+    }
     self.settings.name = self.name;
 }
 

--- a/ooniprobe/Utility/BackgroundTask.m
+++ b/ooniprobe/Utility/BackgroundTask.m
@@ -45,7 +45,7 @@
     //BGAppRefreshTaskRequest *request = [[BGAppRefreshTaskRequest alloc] initWithIdentifier:taskID];
     request.requiresNetworkConnectivity = true;
     request.requiresExternalPower = [SettingsUtility testChargingOnly];
-    request.earliestBeginDate = [NSDate dateWithTimeIntervalSinceNow:0];
+    request.earliestBeginDate = [NSDate dateWithTimeIntervalSinceNow:60*60];
     NSError *error = NULL;
     BOOL success = [[BGTaskScheduler sharedScheduler] submitTaskRequest:request error:&error];
     if (!success) {

--- a/ooniprobe/Utility/BackgroundTask.m
+++ b/ooniprobe/Utility/BackgroundTask.m
@@ -45,7 +45,7 @@
     //BGAppRefreshTaskRequest *request = [[BGAppRefreshTaskRequest alloc] initWithIdentifier:taskID];
     request.requiresNetworkConnectivity = true;
     request.requiresExternalPower = [SettingsUtility testChargingOnly];
-    request.earliestBeginDate = [NSDate dateWithTimeIntervalSinceNow:60*60];
+    request.earliestBeginDate = [NSDate dateWithTimeIntervalSinceNow:0];
     NSError *error = NULL;
     BOOL success = [[BGTaskScheduler sharedScheduler] submitTaskRequest:request error:&error];
     if (!success) {
@@ -77,7 +77,9 @@
     [testSuite setStoreDB:NO];
     AbstractTest *test = [[AbstractTest alloc] initTest:testName];
     [test setStoreDB:NO];
+    [test setAutoRUn:YES];
     [test setAnnotation:YES];
+    test.settings.annotations[@"origin"] = @"autorun";
     [testSuite setTestList:[NSMutableArray arrayWithObject:test]];
     [tests addObject:testSuite];
 
@@ -95,9 +97,11 @@
     
     InstantMessagingSuite *imTest = [[InstantMessagingSuite alloc] init];
     [imTest setStoreDB:NO];
+    [imTest setAutoRUn:YES];
     [tests addObject:imTest];
     CircumventionSuite *cTest = [[CircumventionSuite alloc] init];
     [cTest setStoreDB:NO];
+    [cTest setAutoRUn:YES];
     [tests addObject:cTest];
     ExperimentalSuite *eTest = [[ExperimentalSuite alloc] init];
     [eTest setStoreDB:NO];

--- a/ooniprobe/Utility/BackgroundTask.m
+++ b/ooniprobe/Utility/BackgroundTask.m
@@ -77,9 +77,8 @@
     [testSuite setStoreDB:NO];
     AbstractTest *test = [[AbstractTest alloc] initTest:testName];
     [test setStoreDB:NO];
-    [test setAutoRUn:YES];
+    [test setAutoRun:YES];
     [test setAnnotation:YES];
-    test.settings.annotations[@"origin"] = @"autorun";
     [testSuite setTestList:[NSMutableArray arrayWithObject:test]];
     [tests addObject:testSuite];
 
@@ -97,15 +96,15 @@
     
     InstantMessagingSuite *imTest = [[InstantMessagingSuite alloc] init];
     [imTest setStoreDB:NO];
-    [imTest setAutoRUn:YES];
+    [imTest setAutoRun:YES];
     [tests addObject:imTest];
     CircumventionSuite *cTest = [[CircumventionSuite alloc] init];
     [cTest setStoreDB:NO];
-    [cTest setAutoRUn:YES];
+    [cTest setAutoRun:YES];
     [tests addObject:cTest];
     ExperimentalSuite *eTest = [[ExperimentalSuite alloc] init];
     [eTest setStoreDB:NO];
-    [eTest setAutoRUn:YES];
+    [eTest setAutoRun:YES];
     [tests addObject:eTest];
     [[RunningTest currentTest] setAndRun:[NSMutableArray arrayWithArray:tests]  inView: nil];
 }


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2167

## Proposed Changes

  - Update `getTestList` to set `autoRun` of tests to `YES` when appropriate.
  - Update `AbstractTest` to set `settings.annotations[@"origin"]` to `autorun` and also append `-unattended` to `settings.options.software_name`
