### PR TITLE
chore: use ooni/probe-cli@v3.15.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'ooniprobe' do
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.1/oonimkall.podspec"
+    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.2/oonimkall.podspec"
     pod 'Toast', '~> 4.0.0'
     pod 'MBProgressHUD'
     pod 'DZNEmptyDataSet'
@@ -19,7 +19,7 @@ target 'ooniprobe' do
 end
 
 target 'OONIProbeUnitTests' do
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.1/oonimkall.podspec"
+    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.15.2/oonimkall.podspec"
     pod 'SharkORM', :git => 'https://github.com/sharksync/sharkorm', :tag => 'v2.3.67'
     pod 'OCMapper', '2.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - MBProgressHUD (1.2.0)
   - MKDropdownMenu (1.4)
   - OCMapper (2.0)
-  - oonimkall (2022.06.07-100904)
+  - oonimkall (2022.07.04-102613)
   - RHMarkdownLabel (0.0.1):
     - TTTAttributedLabel
     - XNGMarkdownParser
@@ -30,7 +30,7 @@ DEPENDENCIES:
   - MBProgressHUD
   - MKDropdownMenu
   - OCMapper (= 2.0)
-  - oonimkall (from `https://github.com/ooni/probe-cli/releases/download/v3.15.1/oonimkall.podspec`)
+  - oonimkall (from `https://github.com/ooni/probe-cli/releases/download/v3.15.2/oonimkall.podspec`)
   - RHMarkdownLabel
   - Sentry (from `https://github.com/getsentry/sentry-cocoa.git`, tag `6.1.4`)
   - SharkORM (from `https://github.com/sharksync/sharkorm`, tag `v2.3.67`)
@@ -53,7 +53,7 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   oonimkall:
-    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.15.1/oonimkall.podspec
+    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.15.2/oonimkall.podspec
   Sentry:
     :git: https://github.com/getsentry/sentry-cocoa.git
     :tag: 6.1.4
@@ -78,7 +78,7 @@ SPEC CHECKSUMS:
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   MKDropdownMenu: 269df4a41d21a1db684ce8bc709befe419fc5bae
   OCMapper: 9b4d542543794c42adc01f1493d894f53e193cb0
-  oonimkall: 07f9815f6ef15b087bf64f041b8dfc1e7a4f7d27
+  oonimkall: 87282a39b19a521499a999072615616d8c3de467
   RHMarkdownLabel: 81d6772768e621be57302b7fd5212ad4f78fb0bd
   Sentry: 9d055e2de30a77685e86b219acf02e59b82091fc
   SharkORM: 252e4411923110ac1b524a993ee2b3fa13eed7c4
@@ -86,6 +86,6 @@ SPEC CHECKSUMS:
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: 68dc56c1b0a05d1a352c13479e80fd1eb9ec15c4
+PODFILE CHECKSUM: 1f02e10209a855ec173331004beccff9cd3e18fc
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
This release updates dependencies and fixes a crash on mobile
devices: https://github.com/ooni/probe/issues/2173.

