### PR TITLE
update measurement-log retention policy

### DIFF
--- a/ooniprobe/AppDelegate.m
+++ b/ooniprobe/AppDelegate.m
@@ -98,8 +98,6 @@
     //Called in case the user disable notifications from iOS panel
     if (![[UIApplication sharedApplication] isRegisteredForRemoteNotifications])
         [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"notifications_enabled"];
-    if ([TestUtility canCallDeleteJson])
-        [TestUtility deleteUploadedJsons];
     [TestUtility deleteOldLogs];
     [[Harpy sharedInstance] checkVersionDaily];
 }

--- a/ooniprobe/Test/Test/AbstractTest.m
+++ b/ooniprobe/Test/Test/AbstractTest.m
@@ -167,6 +167,9 @@
                 if (measurement != nil){
                     measurement.is_done = true;
                     [measurement save];
+                    if (measurement.is_uploaded) {
+                        [TestUtility removeFile:[measurement getReportFile]];
+                    }
                 }
             }
             else if ([event.key isEqualToString:@"status.end"]) {

--- a/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
+++ b/ooniprobe/View/TestResults/Footer/UploadFooterViewController.m
@@ -124,6 +124,8 @@
             });
             if (![self uploadMeasurement:currentMeasurement session:session]){
                 errors++;
+            } else {
+                [TestUtility removeFile:[currentMeasurement getReportFile]];
             }
             progress += measurementValue;
             i++;


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2162

## Proposed Changes

  - [x] Delete `Measurement` log when measurement cli emits `status.measurement_done` and measurement has been uploaded.
  - [x] Delete `Measurement` log when measurement is re-submitted.

