### PR TITLE
Background Processing update

### DIFF
--- a/ooniprobe/Test/Test/AbstractTest.m
+++ b/ooniprobe/Test/Test/AbstractTest.m
@@ -72,6 +72,7 @@
         self.backgroundTask = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
             [[UIApplication sharedApplication] endBackgroundTask:self.backgroundTask];
             self.backgroundTask = UIBackgroundTaskInvalid;
+            [self interruptTest];
         }];
         NSError *error;
         self.task = [Engine startExperimentTaskWithSettings:self.settings error:&error];

--- a/ooniprobe/Utility/BackgroundTask.m
+++ b/ooniprobe/Utility/BackgroundTask.m
@@ -30,6 +30,9 @@
 
 //https://uynguyen.github.io/2020/09/26/Best-practice-iOS-background-processing-Background-App-Refresh-Task/
 
+// https://stackoverflow.com/questions/28275415/how-long-does-apple-permit-a-background-task-to-run
+// https://medium.com/swlh/handling-background-tasks-in-ios-13-67f717d94b3d
+
 + (void)handleCheckInTask:(BGTask *)task  API_AVAILABLE(ios(13.0)){
     // Schedule a new task
     [self scheduleCheckIn];


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/2175

## Proposed Changes

  - Call `interruptTest` in expiration handler
