### PR TITLE
OONI Probe Mobile remove RiseupVPN option in Settings

### DIFF
--- a/ooniprobe/Utility/SettingsUtility.m
+++ b/ooniprobe/Utility/SettingsUtility.m
@@ -145,7 +145,7 @@
     else if ([testName isEqualToString:@"circumvention"]) {
         [settings addObject:@"test_psiphon"];
         [settings addObject:@"test_tor"];
-        [settings addObject:@"test_riseupvpn"];
+        /*[settings addObject:@"test_riseupvpn"];*/
     }
     else if ([testName isEqualToString:@"performance"]) {
         [settings addObject:@"run_ndt"];


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/2204

## Proposed Changes

  - Remove `riseupvpn` from settings.

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-01-23 at 21 40 24](https://user-images.githubusercontent.com/17911892/214145424-b0b37498-4e4b-4d69-a44d-e5705bc81197.png)
