### PR TITLE
Fix: Correct null url introduced after change from `downloadUrls` to `checkIn` in #510

### DIFF
--- a/ooniprobe/Utility/OONIApi.m
+++ b/ooniprobe/Utility/OONIApi.m
@@ -40,7 +40,14 @@
     }
     NSMutableArray *urls = [[NSMutableArray alloc] init];
     for (OONIURLInfo* current in result.webConnectivity.urls){
-        [urls addObject:current.url];
+        //List for database
+        Url *url = [Url
+                checkExistingUrl:current.url
+                    categoryCode:current.category_code
+                     countryCode:current.country_code];
+        //List for mk
+        if (url != nil)
+            [urls addObject:url.url];
     }
     if ([urls count] == 0){
         errorcb([NSError errorWithDomain:@"io.ooni.orchestrate"


### PR DESCRIPTION
Fix: Correct null url introduced after change from `downloadUrls` to `checkIn` in #510

## Proposed Changes

  - Add code to save URLs in `OONIApi.checkInCallback` after `OONIApi.checkIn` is called.
