### PR TITLE
Fix: app crashes when disabling all categories

### DIFF
--- a/ooniprobe/Test/Suite/WebsitesSuite.m
+++ b/ooniprobe/Test/Suite/WebsitesSuite.m
@@ -12,7 +12,7 @@
 }
 
 - (NSArray*)getTestList {
-    if ([self.testList count] == 0){
+    if ([self.testList count] == 0 && [SettingsUtility getNumberCategoriesEnabled] > 0){
         [self.testList addObject:[[WebConnectivity alloc] init]];
     }
     return super.getTestList;

--- a/ooniprobe/Test/Test/WebConnectivity.m
+++ b/ooniprobe/Test/Test/WebConnectivity.m
@@ -28,15 +28,7 @@
                 [[NSNotificationCenter defaultCenter] postNotificationName:@"updateRuntime" object:nil];
                 [super runTest];
             } onError:^(NSError *error) {
-                @try {
-                    // Causes Object mapper exception
-                    [ThirdPartyServices recordError:@"downloadUrls_error"
-                                             reason:@"downloadUrls failed due to an error"
-                                           userInfo:[error dictionary]];
-                } @finally {
-                    [[NSNotificationCenter defaultCenter] postNotificationName:@"showError" object:nil];
-                    [super testEnded];
-                }
+                [self onError:error];
             }];
         }
         else {

--- a/ooniprobe/Utility/OONIApi.m
+++ b/ooniprobe/Utility/OONIApi.m
@@ -21,6 +21,12 @@
     if (error != nil) {
         return;
     }
+    
+    if ([SettingsUtility getNumberCategoriesEnabled] <= 0){
+        errorcb(error);
+        return;
+    }
+    
     OONIContext *ooniContext = [session newContextWithTimeout:30];
     OONICheckInConfig *config = [[OONICheckInConfig alloc] initWithSoftwareName:SOFTWARE_NAME
                                                                 softwareVersion:[VersionUtility get_software_version]

--- a/ooniprobe/Utility/OONIApi.m
+++ b/ooniprobe/Utility/OONIApi.m
@@ -23,7 +23,10 @@
     }
     
     if ([SettingsUtility getNumberCategoriesEnabled] <= 0){
-        errorcb(error);
+        errorcb([NSError errorWithDomain:@"io.ooni.orchestrate"
+                                    code:ERR_NO_VALID_URLS
+                                userInfo:@{NSLocalizedDescriptionKey:@"Modal.Error.NoValidUrls"
+                                }]);
         return;
     }
     

--- a/ooniprobe/Utility/ThirdPartyServices.m
+++ b/ooniprobe/Utility/ThirdPartyServices.m
@@ -81,11 +81,11 @@
     NSError *error = [NSError errorWithDomain:title
                                          code:-1001
                                      userInfo:userInfo];
+    // TODO (aanorbel) Call to `SentrySDK` fails causing the app to crash.
+    //  Still to properly investigate and fix.
     @try {
         [SentrySDK captureError:error];
-    }@catch(NSException *e) {
-
-    }@finally {
+    } @catch(NSException *e) {
         NSLog(@"Failed reporting error");
     }
 

--- a/ooniprobe/Utility/ThirdPartyServices.m
+++ b/ooniprobe/Utility/ThirdPartyServices.m
@@ -81,7 +81,14 @@
     NSError *error = [NSError errorWithDomain:title
                                          code:-1001
                                      userInfo:userInfo];
-    [SentrySDK captureError:error];
+    @try {
+        [SentrySDK captureError:error];
+    }@catch(NSException *e) {
+
+    }@finally {
+        NSLog(@"Failed reporting error");
+    }
+
 }
 
 @end


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/2513

## Proposed Changes

  - Disables `WebsitesSuite` if no category is enabled.
  -  Prevent `checkIn` call if no category is enabled.
