### PR TITLE
Feat: Add support for `http` and `https` proxies

### DIFF
--- a/ooniprobe/Utility/ProxySettings.h
+++ b/ooniprobe/Utility/ProxySettings.h
@@ -3,7 +3,9 @@
 typedef NS_ENUM(NSInteger, ProxyProtocol) {
   NONE,
   PSIPHON,
-  SOCKS5
+  SOCKS5,
+  HTTP,
+  HTTPS
 };
 
 @interface ProxySettings : NSObject

--- a/ooniprobe/Utility/ProxySettings.m
+++ b/ooniprobe/Utility/ProxySettings.m
@@ -12,6 +12,10 @@
             self.protocol = PSIPHON;
         } else if ([protocol isEqualToString:[ProxySettings getProtocol:SOCKS5]]) {
             self.protocol = SOCKS5;
+        } else if ([protocol isEqualToString:[ProxySettings getProtocol:HTTP]]) {
+            self.protocol = HTTP;
+        } else if ([protocol isEqualToString:[ProxySettings getProtocol:HTTPS]]) {
+            self.protocol = HTTPS;
         } else {
             // This is where we will extend the code to add support for
             // more proxies, e.g., HTTP proxies.
@@ -30,7 +34,7 @@
 }
 
 - (BOOL)isCustom{
-    if (self.protocol == SOCKS5)
+    if (self.protocol == SOCKS5 || self.protocol == HTTP || self.protocol == HTTPS)
         return true;
     return false;
 }
@@ -45,6 +49,24 @@
         NSString *urlStr = [NSString stringWithFormat:@"socks5://%@:%@/", self.hostname, self.port];
         if ([ProxySettings isIPv6:self.hostname]) {
             urlStr = [NSString stringWithFormat:@"socks5://[%@]:%@/", self.hostname, self.port]; // IPv6 must be quoted in URLs
+        }
+        //URI url = new URI(urlStr);
+        return urlStr;
+    }
+    if (self.protocol == HTTP) {
+        // Alright, we now need to construct a new SOCKS5 URL.
+        NSString *urlStr = [NSString stringWithFormat:@"http://%@:%@/", self.hostname, self.port];
+        if ([ProxySettings isIPv6:self.hostname]) {
+            urlStr = [NSString stringWithFormat:@"http://[%@]:%@/", self.hostname, self.port]; // IPv6 must be quoted in URLs
+        }
+        //URI url = new URI(urlStr);
+        return urlStr;
+    }
+    if (self.protocol == HTTPS) {
+        // Alright, we now need to construct a new SOCKS5 URL.
+        NSString *urlStr = [NSString stringWithFormat:@"https://%@:%@/", self.hostname, self.port];
+        if ([ProxySettings isIPv6:self.hostname]) {
+            urlStr = [NSString stringWithFormat:@"https://[%@]:%@/", self.hostname, self.port]; // IPv6 must be quoted in URLs
         }
         //URI url = new URI(urlStr);
         return urlStr;
@@ -70,6 +92,12 @@
             break;
         case SOCKS5:
             result = @"SOCKS5";
+            break;
+        case HTTP:
+            result = @"http";
+            break;
+        case HTTPS:
+            result = @"https";
             break;
         default:
             result = @"unknown";

--- a/ooniprobe/Utility/ProxySettings.m
+++ b/ooniprobe/Utility/ProxySettings.m
@@ -91,7 +91,7 @@
             result = @"proxy_psiphon";
             break;
         case SOCKS5:
-            result = @"SOCKS5";
+            result = @"socks5";
             break;
         case HTTP:
             result = @"http";

--- a/ooniprobe/View/Settings/ProxyViewController.m
+++ b/ooniprobe/View/Settings/ProxyViewController.m
@@ -33,7 +33,11 @@
         @[[ProxySettings getProtocol:NONE],
           [ProxySettings getProtocol:PSIPHON],
           @"proxy_custom"],
-        @[[ProxySettings getProtocol:SOCKS5]],
+        @[
+                [ProxySettings getProtocol:SOCKS5],
+                [ProxySettings getProtocol:HTTP],
+                [ProxySettings getProtocol:HTTPS]
+        ],
         @[@"proxy_hostname", @"proxy_port"]];
     else
         items = @[@[[ProxySettings getProtocol:NONE],
@@ -124,15 +128,23 @@
         else if (indexPath.row == 1)
             currentProxy.protocol = PSIPHON;
         if (indexPath.row == 2)
-            [self setCustom];
+            [self setCustom:SOCKS5];
+        [self reloadRows];
+    } else if (indexPath.section == 1){
+        if (indexPath.row == 0)
+            [self setCustom:SOCKS5];
+        else if (indexPath.row == 1)
+            [self setCustom:HTTP];
+        else if (indexPath.row == 2)
+            [self setCustom:HTTPS];
         [self reloadRows];
     }
     //[self.view endEditing:YES];
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
 }
 
--(void)setCustom {
-    currentProxy.protocol = SOCKS5;
+- (void)setCustom:(enum ProxyProtocol)protocol {
+    currentProxy.protocol = protocol;
 }
 
 -(BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string


### PR DESCRIPTION
Fixes  https://github.com/ooni/probe/issues/2561

## Proposed Changes

  - Update support for socks proxy to use dropdown for selecting a scheme.
  - Update code to save and retrieve the various proxies.
![Simulator Screenshot - iPhone 15 Pro Max - 2023-10-16 at 15 28 43](https://github.com/ooni/probe-ios/assets/17911892/48a785c2-2849-4c13-aee8-14675c26dad6)

