### PR TITLE
fix: test results show ongoing test instead of older measurements while test is running

### DIFF
--- a/ooniprobe/View/TestResults/Headers/Header1MBViewController.m
+++ b/ooniprobe/View/TestResults/Headers/Header1MBViewController.m
@@ -17,6 +17,9 @@
 
 - (void)resultUpdated:(NSNotification *)notification
 {
+    if (result.Id != ((Result *) [notification object]).Id) {
+        return;
+    }
     result = [notification object];
     [self reloadMeasurement];
 }

--- a/ooniprobe/View/TestResults/Headers/Header1ViewController.m
+++ b/ooniprobe/View/TestResults/Headers/Header1ViewController.m
@@ -18,6 +18,9 @@
 
 - (void)resultUpdated:(NSNotification *)notification
 {
+    if (result.Id != ((Result *) [notification object]).Id) {
+        return;
+    }
     result = [notification object];
     [self reloadMeasurement];
 }

--- a/ooniprobe/View/TestResults/Headers/Header2ViewController.m
+++ b/ooniprobe/View/TestResults/Headers/Header2ViewController.m
@@ -20,6 +20,9 @@
 
 - (void)resultUpdated:(NSNotification *)notification
 {
+    if (result.Id != ((Result *) [notification object]).Id) {
+        return;
+    }
     result = [notification object];
     dispatch_async(dispatch_get_main_queue(), ^{
         [self reloadMeasurement];

--- a/ooniprobe/View/TestResults/Headers/Header3ViewController.m
+++ b/ooniprobe/View/TestResults/Headers/Header3ViewController.m
@@ -19,6 +19,9 @@
 
 - (void)resultUpdated:(NSNotification *)notification
 {
+    if (result.Id != ((Result *) [notification object]).Id) {
+        return;
+    }
     result = [notification object];
     dispatch_async(dispatch_get_main_queue(), ^{
         [self reloadMeasurement];

--- a/ooniprobe/View/TestResults/TestSummaryViewController.m
+++ b/ooniprobe/View/TestResults/TestSummaryViewController.m
@@ -66,6 +66,9 @@
 
 - (void)resultUpdated:(NSNotification *)notification
 {
+    if (result.Id != ((Result *) [notification object]).Id) {
+        return;
+    }
     result = [notification object];
     [self reloadMeasurements];
 }


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2638

## Proposed Changes

  - Check if `result.id` from the incoming update matches `result.id` of the currently visible test result.

