### PR TITLE
chore: use probe-cli v3.20.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,13 +2,22 @@ platform :ios, '9.0'
 use_frameworks!
 inhibit_all_warnings!
 
+
+
+def ooni_pods
+    ooni_version = "v3.20.0"
+    ooni_pods_location = "https://github.com/ooni/probe-cli/releases/download/#{ooni_version}"
+
+    pod "libcrypto", :podspec => "#{ooni_pods_location}/libcrypto.podspec"
+    pod "libevent", :podspec => "#{ooni_pods_location}/libevent.podspec"
+    pod "libssl", :podspec => "#{ooni_pods_location}/libssl.podspec"
+    pod "libtor", :podspec => "#{ooni_pods_location}/libtor.podspec"
+    pod "libz", :podspec => "#{ooni_pods_location}/libz.podspec"
+    pod "oonimkall", :podspec => "#{ooni_pods_location}/oonimkall.podspec"
+end
+
 target 'ooniprobe' do
-    pod "libcrypto", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/libcrypto.podspec"
-    pod "libevent", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/libevent.podspec"
-    pod "libssl", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/libssl.podspec"
-    pod "libtor", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/libtor.podspec"
-    pod "libz", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/libz.podspec"
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/oonimkall.podspec"
+    ooni_pods
     pod 'Toast', '~> 4.0.0'
     pod 'MBProgressHUD'
     pod 'DZNEmptyDataSet'
@@ -24,12 +33,7 @@ target 'ooniprobe' do
 end
 
 target 'OONIProbeUnitTests' do
-    pod "libcrypto", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/libcrypto.podspec"
-    pod "libevent", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/libevent.podspec"
-    pod "libssl", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/libssl.podspec"
-    pod "libtor", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/libtor.podspec"
-    pod "libz", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/libz.podspec"
-    pod "oonimkall", :podspec => "https://github.com/ooni/probe-cli/releases/download/v3.19.1/oonimkall.podspec"
+    ooni_pods
     pod 'SharkORM', :git => 'https://github.com/sharksync/sharkorm', :tag => 'v2.3.67'
     pod 'OCMapper', '2.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,16 +5,16 @@ PODS:
   - DateTools (2.0.0)
   - DZNEmptyDataSet (1.8.1)
   - Harpy (4.1.14)
-  - libcrypto (2023.11.21-145914)
-  - libevent (2023.11.21-145914)
-  - libssl (2023.11.21-145914)
-  - libtor (2023.11.21-145914)
-  - libz (2023.11.21-145914)
+  - libcrypto (2023.12.13-202054)
+  - libevent (2023.12.13-202054)
+  - libssl (2023.12.13-202054)
+  - libtor (2023.12.13-202054)
+  - libz (2023.12.13-202054)
   - lottie-ios (2.5.3)
   - MBProgressHUD (1.2.0)
   - MKDropdownMenu (1.4)
   - OCMapper (2.0)
-  - oonimkall (2023.11.21-145914)
+  - oonimkall (2023.12.13-202054)
   - RHMarkdownLabel (0.0.1):
     - TTTAttributedLabel
     - XNGMarkdownParser
@@ -31,16 +31,16 @@ DEPENDENCIES:
   - DateTools
   - DZNEmptyDataSet
   - Harpy
-  - libcrypto (from `https://github.com/ooni/probe-cli/releases/download/v3.19.1/libcrypto.podspec`)
-  - libevent (from `https://github.com/ooni/probe-cli/releases/download/v3.19.1/libevent.podspec`)
-  - libssl (from `https://github.com/ooni/probe-cli/releases/download/v3.19.1/libssl.podspec`)
-  - libtor (from `https://github.com/ooni/probe-cli/releases/download/v3.19.1/libtor.podspec`)
-  - libz (from `https://github.com/ooni/probe-cli/releases/download/v3.19.1/libz.podspec`)
+  - libcrypto (from `https://github.com/ooni/probe-cli/releases/download/v3.20.0/libcrypto.podspec`)
+  - libevent (from `https://github.com/ooni/probe-cli/releases/download/v3.20.0/libevent.podspec`)
+  - libssl (from `https://github.com/ooni/probe-cli/releases/download/v3.20.0/libssl.podspec`)
+  - libtor (from `https://github.com/ooni/probe-cli/releases/download/v3.20.0/libtor.podspec`)
+  - libz (from `https://github.com/ooni/probe-cli/releases/download/v3.20.0/libz.podspec`)
   - lottie-ios (= 2.5.3)
   - MBProgressHUD
   - MKDropdownMenu
   - OCMapper (= 2.0)
-  - oonimkall (from `https://github.com/ooni/probe-cli/releases/download/v3.19.1/oonimkall.podspec`)
+  - oonimkall (from `https://github.com/ooni/probe-cli/releases/download/v3.20.0/oonimkall.podspec`)
   - RHMarkdownLabel
   - Sentry (from `https://github.com/getsentry/sentry-cocoa.git`, tag `6.1.4`)
   - SharkORM (from `https://github.com/sharksync/sharkorm`, tag `v2.3.67`)
@@ -63,17 +63,17 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   libcrypto:
-    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.19.1/libcrypto.podspec
+    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.20.0/libcrypto.podspec
   libevent:
-    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.19.1/libevent.podspec
+    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.20.0/libevent.podspec
   libssl:
-    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.19.1/libssl.podspec
+    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.20.0/libssl.podspec
   libtor:
-    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.19.1/libtor.podspec
+    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.20.0/libtor.podspec
   libz:
-    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.19.1/libz.podspec
+    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.20.0/libz.podspec
   oonimkall:
-    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.19.1/oonimkall.podspec
+    :podspec: https://github.com/ooni/probe-cli/releases/download/v3.20.0/oonimkall.podspec
   Sentry:
     :git: https://github.com/getsentry/sentry-cocoa.git
     :tag: 6.1.4
@@ -94,16 +94,16 @@ SPEC CHECKSUMS:
   DateTools: 933ac9c490f21f92127cf690ccd8c397e0126caf
   DZNEmptyDataSet: 9525833b9e68ac21c30253e1d3d7076cc828eaa7
   Harpy: b2fbe6819f6a8932df32d7cd2fb20f442df86bbc
-  libcrypto: e58a56228db0e700473cb9453e5fa20bd1e720fe
-  libevent: 2cd74cade500a7976a021ae93119542039026100
-  libssl: bdc3eb5e5333e7fd18d73d2bd15884b8138a080b
-  libtor: 542b5284e16a6d0452eb96ed2616e09f1159a6a7
-  libz: b121b0625931e212e99b0dcfc3b17ac95a8d3683
+  libcrypto: 322086e5d3b16ccf1f55025a55a289995a0cc030
+  libevent: 1753dc8400b0e79fd5f904898591504fa39908e8
+  libssl: daa255515da4b7300ec673027249323d2f1a83a0
+  libtor: 9725121f65813b199cab0573920cab7f97bb990e
+  libz: 5ab697747be11c4a6eb40920f0fa0a714187be53
   lottie-ios: a50d5c0160425cd4b01b852bb9578963e6d92d31
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   MKDropdownMenu: 269df4a41d21a1db684ce8bc709befe419fc5bae
   OCMapper: 9b4d542543794c42adc01f1493d894f53e193cb0
-  oonimkall: dfcbcfc7e5bfe4c47d9805a00b8e43c182766c1f
+  oonimkall: 39f0504bd549c55cbdd805321b36cd68ba78e223
   RHMarkdownLabel: 81d6772768e621be57302b7fd5212ad4f78fb0bd
   Sentry: 9d055e2de30a77685e86b219acf02e59b82091fc
   SharkORM: 252e4411923110ac1b524a993ee2b3fa13eed7c4
@@ -111,6 +111,6 @@ SPEC CHECKSUMS:
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   XNGMarkdownParser: aed98c14f0c0eb20064184ddf9bac26c482722b2
 
-PODFILE CHECKSUM: 791a0b58a247a1b5ae62eaed9769b1d7c69bcaab
+PODFILE CHECKSUM: 8682b6dd76f73766490d3743ab706136560c1d68
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.14.3


### PR DESCRIPTION
## Proposed Changes

  - Extract `ooni` pods and version to make version change easier and less prone to errors.