### PR TITLE
fix: Refine algorithm to group measurements for display.

### DIFF
--- a/ooniprobe/View/TestResults/TestSummaryViewController.h
+++ b/ooniprobe/View/TestResults/TestSummaryViewController.h
@@ -17,5 +17,5 @@
 @property (nonatomic, strong) IBOutlet UITableView *tableView;
 @property (nonatomic, strong) Result* result;
 @property (nonatomic, strong) SRKResultSet *measurements;
-@property (nonatomic, strong) NSArray *groupedMeasurements;
+@property (nonatomic, strong) NSArray<NSArray<Measurement *> *> *groupedMeasurements;
 @end

--- a/ooniprobe/View/TestResults/TestSummaryViewController.m
+++ b/ooniprobe/View/TestResults/TestSummaryViewController.m
@@ -88,7 +88,7 @@
  * where each array of measurements contains only one measurement.
  */
 - (void)groupMeasurements {
-// Create a mutable dictionary to hold the grouped measurements
+    // Create a mutable dictionary to hold the grouped measurements
     NSMutableDictionary *groupedMeasurements = [NSMutableDictionary new];
 
     // Iterate over each measurement
@@ -101,9 +101,9 @@
         if (!groupedMeasurements[testName]) {
             groupedMeasurements[testName] = [@[measurement] mutableCopy];
         }
+        else {
             // If this test_name is already a key in the dictionary, append the current
             // measurement to the existing array
-        else {
             [groupedMeasurements[testName] addObject:measurement];
         }
     }

--- a/ooniprobe/View/TestResults/TestSummaryViewController.m
+++ b/ooniprobe/View/TestResults/TestSummaryViewController.m
@@ -74,7 +74,21 @@
 
 - (void)reloadMeasurements {
     self.measurements = result.measurementsSorted;
-    // Create a mutable dictionary to hold the grouped measurements
+    [self groupMeasurements];
+    [self reloadConstraints];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.tableView reloadData];
+    });
+}
+
+/**
+ * The table takes an array of arrays of measurements.
+ * Each array of measurements is a group of measurements with the same test_name.
+ * If there is only one test_name, it creates an array of arrays of measurements
+ * where each array of measurements contains only one measurement.
+ */
+- (void)groupMeasurements {
+// Create a mutable dictionary to hold the grouped measurements
     NSMutableDictionary *groupedMeasurements = [NSMutableDictionary new];
 
     // Iterate over each measurement
@@ -85,22 +99,32 @@
         // If this test_name is not already a key in the dictionary, add it
         // with the current measurement as the value in an array
         if (!groupedMeasurements[testName]) {
-            groupedMeasurements[testName] = [NSMutableArray arrayWithObject:measurement];
+            groupedMeasurements[testName] = [@[measurement] mutableCopy];
         }
-        // If this test_name is already a key in the dictionary, append the current
-        // measurement to the existing array
+            // If this test_name is already a key in the dictionary, append the current
+            // measurement to the existing array
         else {
             [groupedMeasurements[testName] addObject:measurement];
         }
     }
 
-    // Replace the measurements array with the grouped measurements
-    self.groupedMeasurements = [groupedMeasurements allValues];
-
-    [self reloadConstraints];
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self.tableView reloadData];
-    });
+    // If there is only one test name in the dictionary
+    if (groupedMeasurements.count == 1) {
+        // Create a new array to store groups of measurements
+        NSMutableArray *groups = [[NSMutableArray alloc] init];
+        // Iterate over all measurements for the single test name
+        for (Measurement *measurement in groupedMeasurements.allValues[0]) {
+            // Create a new array for each measurement and add it to the groups array
+            // Set the groupedMeasurements property to the groups array
+            NSMutableArray *measurements = [[NSMutableArray alloc] init];
+            [measurements addObject:measurement];
+            [groups addObject:measurements];
+        }
+        self.groupedMeasurements = [NSArray arrayWithArray:groups];
+    } else {
+        // Replace the measurements array with the grouped measurements
+        self.groupedMeasurements = [groupedMeasurements allValues];
+    }
 }
 
 #pragma mark - Table view data source


### PR DESCRIPTION
Fixes https://github.com/ooni/probe/issues/2657 related to https://github.com/ooni/probe-ios/pull/543

## Proposed Changes

  - Add a condition to create a proper display object if only one group is present.

|.|.|
|-|-|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-01-29 at 10 20 38](https://github.com/ooni/probe-ios/assets/17911892/a6547ac5-1c62-482b-b114-e00791f28010) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-29 at 10 20 42](https://github.com/ooni/probe-ios/assets/17911892/bd334e58-0997-4628-80f6-4c8139b22c7a) |
